### PR TITLE
readme: add missing dot in install instructions

### DIFF
--- a/readme.rst
+++ b/readme.rst
@@ -17,7 +17,7 @@ Installation
     git clone git@github.com:canonical/dashboard.git
     cd dashboard
     python -m venv .venv
-    source ./venv/bin/activate
+    source ./.venv/bin/activate
     pip install -r requirements.txt
 
 


### PR DESCRIPTION
Add missing dot in `.venv`