### PR TITLE
make selected status readable on Projects admin page

### DIFF
--- a/dashboard/static/admin.css
+++ b/dashboard/static/admin.css
@@ -8,7 +8,7 @@ table.objectives tr.condition td, th {padding: 2px 8px 2px;}
 
 table.objectives td p, th p {margin: .2rem 0}
 
-table.objectives select {height: 1.2rem;}
+table.objectives select {height: 1.875rem;}
 
 table.objectives td.workcycle {color: white; background: #6AA84F;}
 table.objectives td.field-committed {color: white; background: #93C47D;}


### PR DESCRIPTION
Adjusts CSS `height` of select box so that selection (Planned, deferred,...) can be read more easily by admin.
Currently the contents of the box are clipped.

Original:

![Screenshot from 2025-02-14 09-57-02](https://github.com/user-attachments/assets/ff2ffd70-7238-41e5-adbd-71f7d47afb18)


Adjusted:

![Screenshot from 2025-02-14 09-57-30](https://github.com/user-attachments/assets/e3068e42-1d22-43b8-ab45-f598dd652347)

Adjusted height is equivalent to other select boxes on the page.