### PR TITLE
Enable debug mode in the uncharmed app, for easier local preview

### DIFF
--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -23,7 +23,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = "django-insecure-&e&n(qvp!ktv&fjr(j8llvz4(5r0!2h9j0lpr=*40bw6z30exn"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = False
+DEBUG = True
 
 ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
This PR enables debug mode in the Django app, so that previewing locally works properly (otherwise the static files aren't loaded). This doesn't affect the rock and charm because the rock version of `settings.py` sets debug mode based on an environment variable.

@evildmp if you know of a better solution for the base Django app, please adjust later!