### PR TITLE
Fixed 'cd' command after reorganising repo

### DIFF
--- a/dashboard/readme.rst
+++ b/dashboard/readme.rst
@@ -13,7 +13,7 @@ Installation
 ::
 
     git clone git@github.com:canonical/dashboard.git
-    cd dashboard
+    cd dashboard/dashboard
     make install
 
 This will create a Python virtual environment in ``.venv`` and install the required dependencies.


### PR DESCRIPTION
This PR fixes the instructions for building the app locally. After I reorganised the repo, the app source is now in a sub directory of the repo.