### PR TITLE
Update rock with latest app changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The application will run in a Kubernetes cluster, so we need a container image f
 Creating the container image might take several minutes, so this is a good point to take a break. When you return, you should see the following output:
 
 > ```
-> Packed dashboard_0.7_amd64.rock
+> Packed dashboard_0.8_amd64.rock
 > ```
 
 ### Create a charm
@@ -117,10 +117,10 @@ Creating the charm might take several minutes, so this is another good point to 
 ``` { name=deploy-dashboard }
 cd ~/dashboard
 rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-  oci-archive:dashboard_0.7_amd64.rock \
-  docker://localhost:32000/dashboard:0.7
+  oci-archive:dashboard_0.8_amd64.rock \
+  docker://localhost:32000/dashboard:0.8
 juju deploy ./charm/dashboard_ubuntu-22.04-amd64.charm \
-  --resource django-app-image=localhost:32000/dashboard:0.7
+  --resource django-app-image=localhost:32000/dashboard:0.8
 ```
 
 The `rockcraft.skopeo` command makes the container image available to Juju.

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -39,6 +39,8 @@ ALLOWED_HOSTS = json.loads(os.environ.get('DJANGO_ALLOWED_HOSTS', '[]'))
 
 INSTALLED_APPS = [
     "whitenoise.runserver_nostatic",
+    # "django_browser_reload",
+    # ^ Used during local development only
     "projects",
     "framework",
     "dashboard",
@@ -61,6 +63,8 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.contrib.admindocs.middleware.XViewMiddleware",
+    # "django_browser_reload.middleware.BrowserReloadMiddleware",
+    # ^ Used during local development only
 ]
 
 ROOT_URLCONF = "dashboard.urls"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@ name: dashboard
 # see https://documentation.ubuntu.com/rockcraft/en/1.8.0/explanation/bases/
 # for more information about bases and using 'bare' bases for chiselled rocks
 base: ubuntu@22.04 # the base environment for this Django application
-version: "0.7" # just for humans. Semantic versioning is recommended
+version: "0.8" # just for humans. Semantic versioning is recommended
 summary: A summary of your Django application # 79 char long summary
 description: |
   Dashboard is a Django application to track quality and progress of multiple


### PR DESCRIPTION
This PR bumps the rock version to 0.8 after the latest app changes (bd79784 onward), including a fix I just made in #31.

I built the image and deployed it alongside postgres. All looks good!

@evildmp - If you're planning further updates to the app in the next couple of days, we can wait for those. Otherwise, let's merge this PR if it looks good to you.