### PR TITLE
Fix calculation of quality_cols_count

### DIFF
--- a/dashboard/projects/views.py
+++ b/dashboard/projects/views.py
@@ -21,7 +21,7 @@ class ProjectListView(ListView):
 
         context["column_count"] = Objective.objects.count() + WorkCycle.objects.count() + 6
 
-        context["quality_cols_count"] = 3 + workcycles.count()
+        context["quality_cols_count"] = 3 + WorkCycle.objects.count()
 
         return context
 


### PR DESCRIPTION
When I was testing the latest changes, I got an error:

> Exception Type: NameError
> Exception Value: name 'workcycles' is not defined
> Exception Location: /django/app/projects/views.py, line 24, in get_context_data
> Raised during: projects.views.ProjectListView

This PR fixes the error.