### PR TITLE
Disable debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The application will run in a Kubernetes cluster, so we need a container image f
 Creating the container image might take several minutes, so this is a good point to take a break. When you return, you should see the following output:
 
 > ```
-> Packed dashboard_0.8_amd64.rock
+> Packed dashboard_0.9_amd64.rock
 > ```
 
 ### Create a charm
@@ -117,10 +117,10 @@ Creating the charm might take several minutes, so this is another good point to 
 ``` { name=deploy-dashboard }
 cd ~/dashboard
 rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-  oci-archive:dashboard_0.8_amd64.rock \
-  docker://localhost:32000/dashboard:0.8
+  oci-archive:dashboard_0.9_amd64.rock \
+  docker://localhost:32000/dashboard:0.9
 juju deploy ./charm/dashboard_ubuntu-22.04-amd64.charm \
-  --resource django-app-image=localhost:32000/dashboard:0.8
+  --resource django-app-image=localhost:32000/dashboard:0.9
 ```
 
 The `rockcraft.skopeo` command makes the container image available to Juju.

--- a/README.md
+++ b/README.md
@@ -141,11 +141,10 @@ After deploying the charm, you should see the following output:
 ### Configure the dashboard
 
 ``` { name=configure-dashboard }
-juju config dashboard django-debug=true
 juju config dashboard django-allowed-hosts='*'
 ```
 
-These commands tell Juju which configuration values to use when the charm starts the dashboard's web server. We're using `django-debug=true` and `django-allowed-hosts='*'` to make it easier to access the dashboard for testing; you wouldn't use these values in a production deployment.
+This command tells Juju which configuration values to use when the charm starts the dashboard's web server. We're using `django-allowed-hosts='*'` to make it easier to access the dashboard for testing; you wouldn't use this value in a production deployment.
 
 ### Deploy a PostgreSQL charm
 

--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -23,7 +23,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = "django-insecure-&e&n(qvp!ktv&fjr(j8llvz4(5r0!2h9j0lpr=*40bw6z30exn"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = ["*"]
 

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@ name: dashboard
 # see https://documentation.ubuntu.com/rockcraft/en/1.8.0/explanation/bases/
 # for more information about bases and using 'bare' bases for chiselled rocks
 base: ubuntu@22.04 # the base environment for this Django application
-version: "0.8" # just for humans. Semantic versioning is recommended
+version: "0.9" # just for humans. Semantic versioning is recommended
 summary: A summary of your Django application # 79 char long summary
 description: |
   Dashboard is a Django application to track quality and progress of multiple


### PR DESCRIPTION
Now that we're including static files (see #32), we should be able to disable debug mode. This PR:

- Disables debug mode in settings.py for the standalone Django app. For testing, I ran the app locally. It looks good.

- Removes the command in the README that enabled debug mode for the charm (in a local deployment). For testing, I packed the rock and deployed the charm locally, without enabling debug mode. It looks good.

I've also bumped the rock version in this PR.