### PR TITLE
Add stripped-prefix charm configuration

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -19,9 +19,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: setup lxd
         uses: canonical/setup-lxd@v0.1.2
-      - name: prepare application source
-        run: |
-          cp dashboard_rock_patch/dashboard/settings.py dashboard/dashboard
       - name: build rock
         run: |
           set -x

--- a/README.md
+++ b/README.md
@@ -43,18 +43,10 @@ In this README:
     ```
     cd
     git clone https://github.com/canonical/dashboard.git
-    ```
-
- 3. Modify the dashboard application so that it takes its configuration from environment variables and expects a PostgreSQL database instead of an SQLite database:
-
-    ``` { name=modify-dashboard }
     cd ~/dashboard
-    cp dashboard_rock_patch/dashboard/settings.py dashboard/dashboard
     ```
 
-    For illustration, compare `DATABASES` in [settings.py (modified)](./dashboard_rock_patch/dashboard/settings.py) and [settings.py (original)](./dashboard/dashboard/settings.py).
-
- 4. Create a "model" in Juju:
+ 3. Create a "model" in Juju:
 
     ``` { name=create-model }
     juju add-model web-k8s
@@ -68,7 +60,7 @@ In this README:
     > Added 'web-k8s' model on microk8s/localhost with credential 'microk8s' for user 'admin'
     > ```
 
- 5. Check the architecture of your machine:
+ 4. Check the architecture of your machine:
 
     ``` { name=check-architecture }
     dpkg --print-architecture
@@ -76,7 +68,7 @@ In this README:
 
     If the output is not `amd64`, you'll need to adjust some of the commands in this README. For example, if the output is `arm64`, you'll need to replace `amd64` by `arm64`.
 
- 6. Configure the Juju model to match the architecture of your machine:
+ 5. Configure the Juju model to match the architecture of your machine:
 
     ``` { name=configure-model }
     juju set-model-constraints -m web-k8s arch=amd64  # remember to replace amd64 if needed!

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -30,6 +30,18 @@ requires:
     interface: postgresql_client
     optional: false
 
+config:
+  options:
+    stripped-prefix:
+      description: |
+        Enable this option when the ingress frontend strips the path prefix before passing requests to the application. 
+        For example, if you are using the nginx-ingress-integrator and set the following configuration:
+        juju config nginx-ingress-integrator path-routes='/documentation(/|$)(.*)' rewrite-enabled='True' rewrite-target='/$2'
+        in this case, set this configuration option to `/documentation`. 
+        This is a temporary solution until the dashboard Django application supports multiple teams. 
+        This configuration option may be removed in the future.
+      type: string
+
 actions:
   load-sample-data:
     description: Load the sample data that comes with the application.

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import urllib.parse
 from pathlib import Path
 
 import json
@@ -33,14 +34,22 @@ DEBUG = os.environ.get('DJANGO_DEBUG', 'false') == 'true'
 
 ALLOWED_HOSTS = json.loads(os.environ.get('DJANGO_ALLOWED_HOSTS', '[]'))
 
+STRIPPED_PREFIX = os.environ.get('DJANGO_STRIPPED_PREFIX', '')
 
+if STRIPPED_PREFIX:
+    STRIPPED_PREFIX = STRIPPED_PREFIX.rstrip('/')
+    FORCE_SCRIPT_NAME = STRIPPED_PREFIX
+    DJANGO_BASE_URL = os.environ.get('DJANGO_BASE_URL')
+    if DJANGO_BASE_URL:
+        parsed_url = urllib.parse.urlparse(DJANGO_BASE_URL)
+        CSRF_TRUSTED_ORIGINS = [
+            f"{parsed_url.scheme}://{parsed_url.netloc}",
+        ]
 
 # Application definition
 
 INSTALLED_APPS = [
     "whitenoise.runserver_nostatic",
-    # "django_browser_reload",
-    # ^ Used during local development only
     "projects",
     "framework",
     "dashboard",
@@ -63,8 +72,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.contrib.admindocs.middleware.XViewMiddleware",
-    # "django_browser_reload.middleware.BrowserReloadMiddleware",
-    # ^ Used during local development only
 ]
 
 ROOT_URLCONF = "dashboard.urls"
@@ -137,7 +144,7 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
-STATIC_URL = "static/"
+STATIC_URL = "static/" if not STRIPPED_PREFIX else f"{STRIPPED_PREFIX}/static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
 
 # Default primary key field type

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -38,3 +38,26 @@ extensions:
 #     stage-packages:
 #       # list required packages or slices for your Django application below.
 #       - libpq-dev
+
+parts:
+  django-framework/install-app:
+    plugin: dump
+    source: dashboard
+    organize:
+      '*': django/app/
+      .*: django/app/
+    stage:
+      - -django/app/db.sqlite3
+      - -django/app/dashboard/settings.py
+    permissions:
+      - owner: 584792
+        group: 584792
+
+  charm-settings-py:
+    plugin: dump
+    source: dashboard_rock_patch
+    organize:
+      '*': django/app/
+    permissions:
+      - owner: 584792
+        group: 584792


### PR DESCRIPTION
Add a new charm configuration option called `stripped-prefix`.

This configuration option is useful when you have an ingress frontend that serves the dashboard Django application on a path prefix and strips that prefix before forwarding the request to the Django application.

For example, configure `nginx-ingress-integrator` and `dashboard` like this:

```
juju config nginx-ingress-integrator path-routes='/documentation(/|$)(.*)' rewrite-enabled='True' rewrite-target='/$2'
juju config dashboard stripped-prefix='/documentation'
```

With this configuration, the dashboard application will be accessible at `https://example.com/documentation` instead of the root `https://example.com/`.

This is a temporary solution until the dashboard Django application supports multiple teams. This configuration option may be removed in the future.
