### PR TITLE
Add a PR template with reminder about rock version

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+
+
+---
+
+### Manual checks:
+
+- [ ] If you changed the Dashboard application or the rock, have you increased the version number in [rockcraft.yaml](./rockcraft.yaml)? Remember to use the same version number in [README.md](./README.md).


### PR DESCRIPTION
When we update the application or rock, we should bump the rock version number. This PR adds a PR template with a manual check. We may need something more automated in the future, but this seems like a good starting point.