### PR TITLE
Fix usernames and passwords in application README

### DIFF
--- a/dashboard/readme.rst
+++ b/dashboard/readme.rst
@@ -47,7 +47,7 @@ Launch the site
     make run
 
 Explore the dashboard at http://localhost:8000/ or 
-login to the admin http://localhost:8000/admin (if you loaded the provided initial data, use admin user ``test``, password ``test``). 
+login to the admin http://localhost:8000/admin (if you loaded the provided initial data, use admin user ``superuser``, password ``superuser`` or user ``driver`, password ``driver``). 
 
 Nearly every cell in the dashboard is a link to the relevant admin view. The most interesting admin view is for *Projects*, for example http://localhost:8000/admin/projects/project/2/change/.
 

--- a/dashboard/readme.rst
+++ b/dashboard/readme.rst
@@ -46,8 +46,10 @@ Launch the site
 
     make run
 
-Explore the dashboard at http://localhost:8000/ or 
-login to the admin http://localhost:8000/admin (if you loaded the provided initial data, use admin user ``superuser``, password ``superuser`` or user ``driver`, password ``driver``). 
+Explore the dashboard at http://localhost:8000/ or log in to the admin interface at http://localhost:8000/admin. If you loaded the provided initial data, log in as one of the following users:
+
+* ``superuser`` with password ``superuser``
+* ``driver`` with password ``driver``
 
 Nearly every cell in the dashboard is a link to the relevant admin view. The most interesting admin view is for *Projects*, for example http://localhost:8000/admin/projects/project/2/change/.
 


### PR DESCRIPTION
Updated default user names/passwords in readme file



---

### Manual checks

- [ ] If you changed the Dashboard application or the rock, have you increased the version number in `rockcraft.yaml`? Remember to use the same version number in `README.md`.
