### PR TITLE
ci(static): Add Makefile target and CI check for collectstatic

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -15,3 +15,7 @@ jobs:
         run: |
           cd dashboard
           make test
+      - name: Check static files
+        run: |
+          cd dashboard
+          make lint

--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -5,7 +5,7 @@ PIP := $(VENV)/bin/pip
 PYTEST := $(VENV)/bin/pytest
 MANAGE := $(VENV)/bin/python ./manage.py
 
-.PHONY: all help clean venv install migrate init test run
+.PHONY: all help clean venv install migrate init test run collectstatic lint
 
 help:
 	@echo "Available targets:"
@@ -31,6 +31,15 @@ init: migrate
 
 run: init
 	$(MANAGE) runserver
+
+collectstatic: install
+	$(MANAGE) collectstatic --no-input
+
+lint: collectstatic
+	@if ! git diff --exit-code --quiet staticfiles/; then \
+		echo "Modified static files detected. Please run 'make collectstatic' and commit the changes."; \
+		exit 1; \
+	fi
 
 test: install
 	$(PIP) install -r requirements-dev.txt


### PR DESCRIPTION
This commit introduces a new check in the CI pipeline to ensure that Django's collected static files are always up-to-date and committed to the repository.

A new `lint` target has been added to the `dashboard/Makefile`. This target first runs `make collectstatic` and then uses `git diff` to verify that there are no uncommitted changes in the `staticfiles/` directory. If changes are detected, the build will fail.

The GitHub Actions workflow has been updated to execute this new `make lint` command, automating the verification process. This prevents developers from forgetting to run `collectstatic` after modifying assets, which could lead to deploying outdated static files.



---

### Manual checks

- [ ] If you changed the Dashboard application or the rock, have you increased the version number in `rockcraft.yaml`? Remember to use the same version number in `README.md`.
