### PR TITLE
Fix broken "Dashboard" link (in production)

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The application will run in a Kubernetes cluster, so we need a container image f
 Creating the container image might take several minutes, so this is a good point to take a break. When you return, you should see the following output:
 
 > ```
-> Packed dashboard_0.25_amd64.rock
+> Packed dashboard_0.26_amd64.rock
 > ```
 
 ### Create a charm
@@ -109,10 +109,10 @@ Creating the charm might take several minutes, so this is another good point to 
 ``` { name=deploy-dashboard }
 cd ~/dashboard
 rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-  oci-archive:dashboard_0.25_amd64.rock \
-  docker://localhost:32000/dashboard:0.25
+  oci-archive:dashboard_0.26_amd64.rock \
+  docker://localhost:32000/dashboard:0.26
 juju deploy ./charm/dashboard_ubuntu-22.04-amd64.charm \
-  --resource django-app-image=localhost:32000/dashboard:0.25
+  --resource django-app-image=localhost:32000/dashboard:0.26
 ```
 
 The `rockcraft.skopeo` command makes the container image available to Juju.

--- a/dashboard/projects/templates/projects/project.html
+++ b/dashboard/projects/templates/projects/project.html
@@ -18,7 +18,7 @@
 
     <nav class="navigation">
       <ul>
-        <li><a href="/">Dashboard</a></li>
+        <li><a href="{% url 'projects:project_list' %}">Dashboard</a></li>
         {% if user.is_authenticated %}
           <li><a href="{% url 'admin:index' %}">Admin</a></li>
           <li>Logged in as {{ user.username }}</li>

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@ name: dashboard
 # see https://documentation.ubuntu.com/rockcraft/en/1.8.0/explanation/bases/
 # for more information about bases and using 'bare' bases for chiselled rocks
 base: ubuntu@22.04 # the base environment for this Django application
-version: "0.25" # just for humans. Semantic versioning is recommended
+version: "0.26" # just for humans. Semantic versioning is recommended
 summary: A summary of your Django application # 79 char long summary
 description: |
   Dashboard is a Django application to track quality and progress of multiple


### PR DESCRIPTION
In our production deployment of the application, the "Dashboard" link at the top of project pages is broken because the href is `/` instead of `documentation/`. This PR applies a similar fix as in https://github.com/canonical/dashboard/pull/37, making the URL dynamic.

---

### Manual checks

- [X] If you changed the Dashboard application or the rock, have you increased the version number in `rockcraft.yaml`? Remember to use the same version number in `README.md`.