### PR TITLE
Fix the "last review" datepicker in Chrome

### DIFF
--- a/dashboard/projects/forms.py
+++ b/dashboard/projects/forms.py
@@ -1,9 +1,6 @@
 from . import models
 from django import forms
 
-class DatePickerInput(forms.DateInput):
-    input_type = 'date'
-
 
 class ProjectDetailForm(forms.ModelForm):
 
@@ -20,10 +17,11 @@ class ProjectDetailForm(forms.ModelForm):
             "last_review_status",
         ]
         widgets = {
-            'last_review' : DatePickerInput(),
+            'last_review': forms.DateInput(
+                attrs={'type': 'date'},
+                format='%Y-%m-%d',
+            )
         }
-
-    # last_review = forms.DateField(widget=forms.DateInput)
 
 
 class ProjectObjectiveForm(forms.ModelForm):

--- a/dashboard/test_browser.py
+++ b/dashboard/test_browser.py
@@ -129,5 +129,6 @@ def test_status(page):
         "First results"
     )
 
+
 def test_last_review(page):
     expect(page.get_by_role("textbox", name="Last review:")).to_have_value("2024-12-16")

--- a/dashboard/test_browser.py
+++ b/dashboard/test_browser.py
@@ -128,3 +128,6 @@ def test_status(page):
     expect(page.get_by_test_id("projectobjective_status_1")).to_contain_text(
         "First results"
     )
+
+def test_last_review(page):
+    expect(page.get_by_role("textbox", name="Last review:")).to_have_value("2024-12-16")


### PR DESCRIPTION
In Chrome, the last review datepicker did not display values correctly.

This patch formats the form value using '%Y-%m-%d'.

A regression test is included in test_browser.py