### PR TITLE
Fixes incorrect status level

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -15,6 +15,10 @@ jobs:
         run: |
           cd dashboard
           make test-framework
+      - name: Run projects tests
+        run: |
+          cd dashboard
+          make test-projects
       - name: Run browser tests
         run: |
           cd dashboard

--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -46,11 +46,15 @@ collectstatic-check: collectstatic
 		exit 1; \
 	fi
 
-test: test-framework test-browser
+test: test-framework test-projects test-browser
 
 # For use in CI
 test-framework: install-dev
 	$(PYTEST) framework
+
+# For use in CI
+test-projects: install-dev
+	$(PYTEST) projects
 
 # For use in CI
 test-browser: install-dev

--- a/dashboard/projects/models.py
+++ b/dashboard/projects/models.py
@@ -150,9 +150,11 @@ class ProjectObjective(models.Model):
 
         # we found some done/not_applicable, so need to check level by level
         # to see if there is a complete level
-        level_achieved = None
 
-        for level in Level.objects.all():
+        level_achieved = None
+        for level in Level.objects.filter(
+            condition__in=Condition.objects.filter(objective=self.objective)
+        ):
 
             # nothing in this level? return
             if ProjectObjectiveCondition.objects.filter(

--- a/dashboard/projects/test_models.py
+++ b/dashboard/projects/test_models.py
@@ -1,9 +1,5 @@
-import datetime
-from pytest_django.asserts import assertQuerySetEqual
-
 import pytest
 
-from framework.models import *
 from projects.models import *
 
 

--- a/dashboard/projects/test_models.py
+++ b/dashboard/projects/test_models.py
@@ -1,0 +1,44 @@
+import datetime
+from pytest_django.asserts import assertQuerySetEqual
+
+import pytest
+
+from framework.models import *
+from projects.models import *
+
+
+@pytest.mark.django_db
+def test_expectations_are_confirmed():
+    project = Project.objects.create(name="project")
+    level1 = Level.objects.create(name="level_1", value=1)
+    level2 = Level.objects.create(name="level_2", value=2)
+    level3 = Level.objects.create(name="level_3", value=3)
+    objective1 = Objective.objects.create(name="objective_1", weight=1)
+    condition1 = Condition.objects.create(
+        name="condition_1", level=level1, objective=objective1
+    )
+    condition2 = Condition.objects.create(
+        name="condition_2", level=level3, objective=objective1
+    )
+
+    # the objective meets level 1
+    ProjectObjectiveCondition.objects.filter(
+        project=project,
+        objective=objective1,
+        condition=condition1,
+    ).update(done=True)
+    assert (
+        ProjectObjective.objects.get(project=project, objective=objective1).status()
+        == level1
+    )
+
+    # the objective meets level 3
+    ProjectObjectiveCondition.objects.filter(
+        project=project,
+        objective=objective1,
+        condition=condition2,
+    ).update(done=True)
+    assert (
+        ProjectObjective.objects.get(project=project, objective=objective1).status()
+        == level3
+    )


### PR DESCRIPTION
When an objective's commitments don't include a level, the status result could be wrong, reporting the missing level as achieved.

This fixes that by only checking for levels that are actually part of the objective's commitments.

Includes a test.