### PR TITLE
Restructure "Designing a quality framework" doc

### DIFF
--- a/docs/designing-framework.rst
+++ b/docs/designing-framework.rst
@@ -54,7 +54,7 @@ While designing your framework, you will often need to hush your inner rationali
 Defining objectives
 -------------------
 
-Consider a dimension of quality in your field, an aspect that you care about - like *Inclusive language* or *Automated spelling checks*
+Consider a dimension of quality in your field, an aspect that you care about - like *Inclusive language* or *Automated spelling checks*.
 
 Whatever it is, it should be something meaningful and recognisable to the people that you expect to work with the framework.
 


### PR DESCRIPTION
Continuing from #121, I think we can me make [Designing a quality framework](https://documentation.ubuntu.com/dashboard/designing-framework/) easier to follow by reorganising the headings. This is a matter of taste and I don't mind if we prefer to go in a different direction.

**[Preview doc](https://canonical-ubuntu-documentation-library--123.com.readthedocs.build/dashboard/designing-framework/)**