### PR TITLE
Fix level calculation in production

### DIFF
--- a/dashboard/projects/models.py
+++ b/dashboard/projects/models.py
@@ -158,6 +158,7 @@ class ProjectObjective(models.Model):
                     ),
                 )
             )
+            .order_by("value")
         )
 
         level_achieved = None


### PR DESCRIPTION
Fixes #124 by specifying the order of levels when calculating achieved level.

I haven't bumped the rock version because I'll merge this immediately before #126.