### PR TITLE
Adjust OIDC configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The application will run in a Kubernetes cluster, so we need a container image f
 Creating the container image might take several minutes, so this is a good point to take a break. When you return, you should see the following output:
 
 > ```
-> Packed dashboard_0.50_amd64.rock
+> Packed dashboard_0.51_amd64.rock
 > ```
 
 ### Create a charm
@@ -109,10 +109,10 @@ Creating the charm might take several minutes, so this is another good point to 
 ``` { name=deploy-dashboard }
 cd ~/dashboard
 rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-  oci-archive:dashboard_0.50_amd64.rock \
+  oci-archive:dashboard_0.51_amd64.rock \
   docker://localhost:32000/dashboard:0.49
 juju deploy ./charm/dashboard_ubuntu-22.04-amd64.charm \
-  --resource django-app-image=localhost:32000/dashboard:0.50
+  --resource django-app-image=localhost:32000/dashboard:0.51
 ```
 
 The `rockcraft.skopeo` command makes the container image available to Juju.

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -59,6 +59,11 @@ config:
         HTTPS, regardless of what the upstream ingress returns in the ingress URL.
         It may cause some unforeseeable ingress issues, so avoid using this option if possible.
       default: false
+    oidc-login-button-text:
+      type: string
+      default: Your company login
+      description: >-
+        This option controls the application's login button text if you integrate with an OpenID Connect provider.
 
 actions:
   load-sample-data:

--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -73,7 +73,6 @@ LOGGING = {
     },
 }
 
-
 # OIDC Settings - Loaded from .env file
 OIDC_RP_CLIENT_ID = os.environ.get("DJANGO_OIDC_CLIENT_ID")
 OIDC_RP_CLIENT_SECRET = os.environ.get("DJANGO_OIDC_CLIENT_SECRET")
@@ -81,12 +80,16 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("DJANGO_OIDC_AUTHORIZE_URL")
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
 OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USERINFO_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
-OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get("DJANGO_OIDC_AUTHENTICATION_CALLBACK_URL")
+OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get(
+    "DJANGO_OIDC_AUTHENTICATION_CALLBACK_URL"
+)
 
 # Optional OIDC Settings
 OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_RP_SCOPES = "openid email profile"
-OIDC_TOKEN_USE_BASIC_AUTH = True  # Use client_secret_basic instead of client_secret_post
+OIDC_TOKEN_USE_BASIC_AUTH = (
+    True  # Use client_secret_basic instead of client_secret_post
+)
 OIDC_LOGIN_BUTTON_TEXT = "Your Company Login"  # Customize this text as needed
 
 # Session settings for OIDC
@@ -218,7 +221,9 @@ AUTHENTICATION_BACKENDS = [
 
 # Add OIDC authentication backend only if configured
 if OIDC_RP_CLIENT_ID:
-    AUTHENTICATION_BACKENDS.insert(0, "mozilla_django_oidc.auth.OIDCAuthenticationBackend")
+    AUTHENTICATION_BACKENDS.insert(
+        0, "mozilla_django_oidc.auth.OIDCAuthenticationBackend"
+    )
 
 
 TINYMCE_DEFAULT_CONFIG = {

--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -85,12 +85,14 @@ OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get(
 )
 
 # Optional OIDC Settings
-OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_RP_SCOPES = os.environ.get("DJANGO_OIDC_SCOPES", "openid email profile")
+OIDC_LOGIN_BUTTON_TEXT = os.environ.get(
+    "DJANGO_OIDC_LOGIN_BUTTON_TEXT", "Your company login"
+)
+OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_TOKEN_USE_BASIC_AUTH = (
     True  # Use client_secret_basic instead of client_secret_post
 )
-OIDC_LOGIN_BUTTON_TEXT = "Your Company Login"  # Customize this text as needed
 
 # Session settings for OIDC
 OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = 15 * 60  # 15 minutes

--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -80,7 +80,7 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("DJANGO_OIDC_AUTHORIZE_URL")
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
 OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USER_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
-OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get(
+OIDC_AUTHENTICATION_CALLBACK_URL = (
     "oidc_authentication_callback"  # Use /oidc/callback, per mozilla library
 )
 

--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -81,12 +81,12 @@ OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
 OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USERINFO_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
 OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get(
-    "DJANGO_OIDC_AUTHENTICATION_CALLBACK_URL"
+    "oidc_authentication_callback"  # Use /oidc/callback, per mozilla library
 )
 
 # Optional OIDC Settings
 OIDC_RP_SIGN_ALGO = "RS256"
-OIDC_RP_SCOPES = "openid email profile"
+OIDC_RP_SCOPES = os.environ.get("DJANGO_OIDC_SCOPES", "openid email profile")
 OIDC_TOKEN_USE_BASIC_AUTH = (
     True  # Use client_secret_basic instead of client_secret_post
 )

--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -78,7 +78,7 @@ OIDC_RP_CLIENT_ID = os.environ.get("DJANGO_OIDC_CLIENT_ID")
 OIDC_RP_CLIENT_SECRET = os.environ.get("DJANGO_OIDC_CLIENT_SECRET")
 OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("DJANGO_OIDC_AUTHORIZE_URL")
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
-OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USERINFO_URL")
+OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USER_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
 OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get(
     "oidc_authentication_callback"  # Use /oidc/callback, per mozilla library

--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -80,9 +80,8 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("DJANGO_OIDC_AUTHORIZE_URL")
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
 OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USER_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
-OIDC_AUTHENTICATION_CALLBACK_URL = (
-    "oidc_authentication_callback"  # Use /oidc/callback, per mozilla library
-)
+
+# The callback path will be /oidc/callback - see dashboard/dashboard/urls.py
 
 # Optional OIDC Settings
 OIDC_RP_SCOPES = os.environ.get("DJANGO_OIDC_SCOPES", "openid email profile")

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -97,20 +97,24 @@ LOGGING = {
     },
 }
 
-# OIDC Settings 
+# OIDC Settings
 OIDC_RP_CLIENT_ID = os.environ.get("DJANGO_OIDC_CLIENT_ID")
 OIDC_RP_CLIENT_SECRET = os.environ.get("DJANGO_OIDC_CLIENT_SECRET")
 OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("DJANGO_OIDC_AUTHORIZE_URL")
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
 OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USERINFO_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
-OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get("DJANGO_OIDC_AUTHENTICATION_CALLBACK_URL")
+OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get(
+    "DJANGO_OIDC_AUTHENTICATION_CALLBACK_URL"
+)
 
 # Optional OIDC Settings
 OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_RP_SCOPES = "openid email profile"
-OIDC_TOKEN_USE_BASIC_AUTH = True  # Use client_secret_basic instead of client_secret_post
-OIDC_LOGIN_BUTTON_TEXT = "Your Company Login" 
+OIDC_TOKEN_USE_BASIC_AUTH = (
+    True  # Use client_secret_basic instead of client_secret_post
+)
+OIDC_LOGIN_BUTTON_TEXT = "Your Company Login"
 
 # Session settings for OIDC
 OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = 15 * 60  # 15 minutes
@@ -237,8 +241,9 @@ AUTHENTICATION_BACKENDS = [
 
 # Add OIDC authentication backend only if configured
 if OIDC_RP_CLIENT_ID:
-    AUTHENTICATION_BACKENDS.insert(0, "mozilla_django_oidc.auth.OIDCAuthenticationBackend")
-
+    AUTHENTICATION_BACKENDS.insert(
+        0, "mozilla_django_oidc.auth.OIDCAuthenticationBackend"
+    )
 
 
 TINYMCE_DEFAULT_CONFIG = {
@@ -251,4 +256,3 @@ TINYMCE_DEFAULT_CONFIG = {
     "statusbar": False,
     "valid_elements": "a[href|target=_blank],strong,em,p,ul,ol,li",
 }
-

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -109,15 +109,18 @@ OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get(
 )
 
 # Optional OIDC Settings
-OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_RP_SCOPES = os.environ.get("DJANGO_OIDC_SCOPES", "openid email profile")
+OIDC_LOGIN_BUTTON_TEXT = os.environ.get(
+    "DJANGO_OIDC_LOGIN_BUTTON_TEXT"  # Default value will be configured by the charm
+)
+OIDC_RP_SIGN_ALGO = "RS256"
 OIDC_TOKEN_USE_BASIC_AUTH = (
     True  # Use client_secret_basic instead of client_secret_post
 )
-OIDC_LOGIN_BUTTON_TEXT = "Your Company Login"
 
 # Session settings for OIDC
 OIDC_RENEW_ID_TOKEN_EXPIRY_SECONDS = 15 * 60  # 15 minutes
+
 
 # Application definition
 

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -102,7 +102,7 @@ OIDC_RP_CLIENT_ID = os.environ.get("DJANGO_OIDC_CLIENT_ID")
 OIDC_RP_CLIENT_SECRET = os.environ.get("DJANGO_OIDC_CLIENT_SECRET")
 OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("DJANGO_OIDC_AUTHORIZE_URL")
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
-OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USERINFO_URL")
+OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USER_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
 OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get(
     "oidc_authentication_callback"  # Use /oidc/callback, per mozilla library

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -104,7 +104,7 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("DJANGO_OIDC_AUTHORIZE_URL")
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
 OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USER_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
-OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get(
+OIDC_AUTHENTICATION_CALLBACK_URL = (
     "oidc_authentication_callback"  # Use /oidc/callback, per mozilla library
 )
 

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -104,9 +104,8 @@ OIDC_OP_AUTHORIZATION_ENDPOINT = os.environ.get("DJANGO_OIDC_AUTHORIZE_URL")
 OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
 OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USER_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
-OIDC_AUTHENTICATION_CALLBACK_URL = (
-    "oidc_authentication_callback"  # Use /oidc/callback, per mozilla library
-)
+
+# The callback path will be /oidc/callback - see dashboard/dashboard/urls.py
 
 # Optional OIDC Settings
 OIDC_RP_SCOPES = os.environ.get("DJANGO_OIDC_SCOPES", "openid email profile")

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -105,12 +105,12 @@ OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
 OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USERINFO_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
 OIDC_AUTHENTICATION_CALLBACK_URL = os.environ.get(
-    "DJANGO_OIDC_AUTHENTICATION_CALLBACK_URL"
+    "oidc_authentication_callback"  # Use /oidc/callback, per mozilla library
 )
 
 # Optional OIDC Settings
 OIDC_RP_SIGN_ALGO = "RS256"
-OIDC_RP_SCOPES = "openid email profile"
+OIDC_RP_SCOPES = os.environ.get("DJANGO_OIDC_SCOPES", "openid email profile")
 OIDC_TOKEN_USE_BASIC_AUTH = (
     True  # Use client_secret_basic instead of client_secret_post
 )

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@ name: dashboard
 # see https://documentation.ubuntu.com/rockcraft/en/1.8.0/explanation/bases/
 # for more information about bases and using 'bare' bases for chiselled rocks
 base: ubuntu@22.04 # the base environment for this Django application
-version: "0.49" # just for humans. Semantic versioning is recommended
+version: "0.51" # just for humans. Semantic versioning is recommended
 summary: A summary of your Django application # 79 char long summary
 description: |
   Dashboard is a Django application to track quality and progress of multiple


### PR DESCRIPTION
This PR adjusts the OIDC configuration after I did some more testing. Main changes:

- Hardcoded the callback path instead of having it configurable, since the identity provider should follow whatever the application defines. We're using `/oidc/callback`.
- Fixed the name of the environment variable for setting the user endpoint, based on the name that comes via [oauth-external-idp-integrator](https://github.com/canonical/oauth-external-idp-integrator) and the PaaS charm.
- Made the login button text configurable at the charm level.

---

### Manual checks

- [x] If you changed the Dashboard application or the rock, have you increased the version number in `rockcraft.yaml`? Remember to use the same version number in `README.md`.
