### PR TITLE
Fix login URL for OIDC

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The application will run in a Kubernetes cluster, so we need a container image f
 Creating the container image might take several minutes, so this is a good point to take a break. When you return, you should see the following output:
 
 > ```
-> Packed dashboard_0.51_amd64.rock
+> Packed dashboard_0.52_amd64.rock
 > ```
 
 ### Create a charm
@@ -109,10 +109,10 @@ Creating the charm might take several minutes, so this is another good point to 
 ``` { name=deploy-dashboard }
 cd ~/dashboard
 rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-  oci-archive:dashboard_0.51_amd64.rock \
+  oci-archive:dashboard_0.52_amd64.rock \
   docker://localhost:32000/dashboard:0.49
 juju deploy ./charm/dashboard_ubuntu-22.04-amd64.charm \
-  --resource django-app-image=localhost:32000/dashboard:0.51
+  --resource django-app-image=localhost:32000/dashboard:0.52
 ```
 
 The `rockcraft.skopeo` command makes the container image available to Juju.

--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -210,7 +210,7 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
-LOGIN_URL = "/accounts/login/"
+LOGIN_URL = "login"
 
 LOGIN_REDIRECT_URL = "projects:project_list"
 LOGOUT_REDIRECT_URL = "projects:project_list"

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -232,6 +232,7 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+LOGIN_URL = "login"
 
 LOGIN_REDIRECT_URL = "projects:project_list"
 LOGOUT_REDIRECT_URL = "projects:project_list"

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@ name: dashboard
 # see https://documentation.ubuntu.com/rockcraft/en/1.8.0/explanation/bases/
 # for more information about bases and using 'bare' bases for chiselled rocks
 base: ubuntu@22.04 # the base environment for this Django application
-version: "0.51" # just for humans. Semantic versioning is recommended
+version: "0.52" # just for humans. Semantic versioning is recommended
 summary: A summary of your Django application # 79 char long summary
 description: |
   Dashboard is a Django application to track quality and progress of multiple


### PR DESCRIPTION
If OIDC is enabled, the Django app requires login, redirecting to `LOGIN_URL` as defined in `settings.py`. The default value `/accounts/login/` works when running the app from source. However, in our production deployment, the URL needs to be `/<instance>/accounts/login/`. This PR fixes the issue by setting `LOGIN_URL` to the named URL pattern `login`, which resolves to the correct login URL.

We use the same named URL pattern for the "log in" button on project pages:

https://github.com/canonical/dashboard/blob/99a353ae331484efc30729d64a3b64b7075a3b71/dashboard/projects/templates/projects/project.html#L32

---

### Manual checks

- [x] If you changed the Dashboard application or the rock, have you increased the version number in `rockcraft.yaml`? Remember to use the same version number in `README.md`.
