### PR TITLE
Include OIDC app and settings template in app settings for rock

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The application will run in a Kubernetes cluster, so we need a container image f
 Creating the container image might take several minutes, so this is a good point to take a break. When you return, you should see the following output:
 
 > ```
-> Packed dashboard_0.52_amd64.rock
+> Packed dashboard_0.53_amd64.rock
 > ```
 
 ### Create a charm
@@ -109,10 +109,10 @@ Creating the charm might take several minutes, so this is another good point to 
 ``` { name=deploy-dashboard }
 cd ~/dashboard
 rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-  oci-archive:dashboard_0.52_amd64.rock \
+  oci-archive:dashboard_0.53_amd64.rock \
   docker://localhost:32000/dashboard:0.49
 juju deploy ./charm/dashboard_ubuntu-22.04-amd64.charm \
-  --resource django-app-image=localhost:32000/dashboard:0.52
+  --resource django-app-image=localhost:32000/dashboard:0.53
 ```
 
 The `rockcraft.skopeo` command makes the container image available to Juju.

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -168,6 +168,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "dashboard.auth_decorators.oidc_settings",
             ],
         },
     },

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -138,6 +138,10 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
 ]
 
+# Add OIDC app only if configured
+if OIDC_RP_CLIENT_ID:
+    INSTALLED_APPS.insert(3, "mozilla_django_oidc")
+
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@ name: dashboard
 # see https://documentation.ubuntu.com/rockcraft/en/1.8.0/explanation/bases/
 # for more information about bases and using 'bare' bases for chiselled rocks
 base: ubuntu@22.04 # the base environment for this Django application
-version: "0.52" # just for humans. Semantic versioning is recommended
+version: "0.53" # just for humans. Semantic versioning is recommended
 summary: A summary of your Django application # 79 char long summary
 description: |
   Dashboard is a Django application to track quality and progress of multiple


### PR DESCRIPTION
This PR syncs the rock version of `settings.py` with our other `settings.py` file, to make sure that OIDC is correctly configured in the Django app.

---

### Manual checks

- [x] If you changed the Dashboard application or the rock, have you increased the version number in `rockcraft.yaml`? Remember to use the same version number in `README.md`.
