### PR TITLE
Fix version mismatch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Creating the charm might take several minutes, so this is another good point to 
 cd ~/dashboard
 rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
   oci-archive:dashboard_0.53_amd64.rock \
-  docker://localhost:32000/dashboard:0.49
+  docker://localhost:32000/dashboard:0.53
 juju deploy ./charm/dashboard_ubuntu-22.04-amd64.charm \
   --resource django-app-image=localhost:32000/dashboard:0.53
 ```


### PR DESCRIPTION
Thanks @SecondSkoll for noticing that the local deployment instructions don't work because of a version mismatch!