### PR TITLE
Decouple login requirement from OIDC detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The application will run in a Kubernetes cluster, so we need a container image f
 Creating the container image might take several minutes, so this is a good point to take a break. When you return, you should see the following output:
 
 > ```
-> Packed dashboard_0.54_amd64.rock
+> Packed dashboard_0.55_amd64.rock
 > ```
 
 ### Create a charm
@@ -109,10 +109,10 @@ Creating the charm might take several minutes, so this is another good point to 
 ``` { name=deploy-dashboard }
 cd ~/dashboard
 rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-  oci-archive:dashboard_0.54_amd64.rock \
-  docker://localhost:32000/dashboard:0.54
+  oci-archive:dashboard_0.55_amd64.rock \
+  docker://localhost:32000/dashboard:0.55
 juju deploy ./charm/dashboard_ubuntu-22.04-amd64.charm \
-  --resource django-app-image=localhost:32000/dashboard:0.54
+  --resource django-app-image=localhost:32000/dashboard:0.55
 ```
 
 The `rockcraft.skopeo` command makes the container image available to Juju.

--- a/charm/charmcraft.yaml
+++ b/charm/charmcraft.yaml
@@ -59,6 +59,10 @@ config:
         HTTPS, regardless of what the upstream ingress returns in the ingress URL.
         It may cause some unforeseeable ingress issues, so avoid using this option if possible.
       default: false
+    force-login:
+      type: boolean
+      description: >-
+        This option controls whether users are required to log in to view the project list and project detail pages.
     oidc-login-button-text:
       type: string
       default: Your company login

--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -81,6 +81,7 @@ test-projects: install-dev
 	$(PYTEST) test_browser.py
 
 oidc-test-framework: install-dev
+	DJANGO_FORCE_LOGIN=true \
 	DJANGO_OIDC_CLIENT_ID=fake_client_id \
 	DJANGO_OIDC_CLIENT_SECRET=fake_client_secret \
 	DJANGO_OIDC_AUTHORIZE_URL=https://example.com/oauth2/auth \
@@ -90,6 +91,7 @@ oidc-test-framework: install-dev
 	$(PYTEST) framework
 
 oidc-test-projects: install-dev
+	DJANGO_FORCE_LOGIN=true \
 	DJANGO_OIDC_CLIENT_ID=fake_client_id \
 	DJANGO_OIDC_CLIENT_SECRET=fake_client_secret \
 	DJANGO_OIDC_AUTHORIZE_URL=https://example.com/oauth2/auth \
@@ -100,6 +102,7 @@ oidc-test-projects: install-dev
 
 oidc-test-browser: install-dev
 	$(VENV)/bin/python -m playwright install
+	DJANGO_FORCE_LOGIN=true \
 	DJANGO_OIDC_CLIENT_ID=fake_client_id \
 	DJANGO_OIDC_CLIENT_SECRET=fake_client_secret \
 	DJANGO_OIDC_AUTHORIZE_URL=https://example.com/oauth2/auth \

--- a/dashboard/dashboard/auth_decorators.py
+++ b/dashboard/dashboard/auth_decorators.py
@@ -23,7 +23,7 @@ class ConditionalLoginRequiredMixin(LoginRequiredMixin):
     """
     def dispatch(self, request, *args, **kwargs):
         # Only require login if OIDC is configured
-        if settings.OIDC_RP_CLIENT_ID:
+        if settings.FORCE_LOGIN:
             return super().dispatch(request, *args, **kwargs)
         # Otherwise, skip login requirement
         return super(LoginRequiredMixin, self).dispatch(request, *args, **kwargs)
@@ -37,7 +37,7 @@ def conditional_login_required(view_func):
     @wraps(view_func)
     def wrapper(request, *args, **kwargs):
         # Only require login if OIDC is configured
-        if settings.OIDC_RP_CLIENT_ID:
+        if settings.FORCE_LOGIN:
             return login_required(view_func)(request, *args, **kwargs)
         return view_func(request, *args, **kwargs)
     return wrapper

--- a/dashboard/dashboard/auth_decorators.py
+++ b/dashboard/dashboard/auth_decorators.py
@@ -22,10 +22,8 @@ class ConditionalLoginRequiredMixin(LoginRequiredMixin):
     When OIDC is not configured, allows anonymous access.
     """
     def dispatch(self, request, *args, **kwargs):
-        # Only require login if OIDC is configured
         if settings.FORCE_LOGIN:
             return super().dispatch(request, *args, **kwargs)
-        # Otherwise, skip login requirement
         return super(LoginRequiredMixin, self).dispatch(request, *args, **kwargs)
 
 
@@ -36,7 +34,6 @@ def conditional_login_required(view_func):
     """
     @wraps(view_func)
     def wrapper(request, *args, **kwargs):
-        # Only require login if OIDC is configured
         if settings.FORCE_LOGIN:
             return login_required(view_func)(request, *args, **kwargs)
         return view_func(request, *args, **kwargs)

--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -73,6 +73,8 @@ LOGGING = {
     },
 }
 
+FORCE_LOGIN = os.environ.get("DJANGO_FORCE_LOGIN", "false").lower() == "true"
+
 # OIDC Settings - Loaded from .env file
 OIDC_RP_CLIENT_ID = os.environ.get("DJANGO_OIDC_CLIENT_ID")
 OIDC_RP_CLIENT_SECRET = os.environ.get("DJANGO_OIDC_CLIENT_SECRET")

--- a/dashboard/projects/test_views.py
+++ b/dashboard/projects/test_views.py
@@ -336,16 +336,16 @@ def test_project_list_renders_qi_history_current_qi_and_levels(
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_RP_CLIENT_ID=None)
-def test_project_list_no_login(client):
+@override_settings(FORCE_LOGIN=False)
+def test_no_login_project_list(client):
     url = reverse("projects:project_list")
     response = client.get(url)
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_RP_CLIENT_ID="test_client_id")
-def test_project_list_oidc_needs_login(client):
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_project_list(client):
     url = reverse("projects:project_list")
     response = client.get(url)
     assert response.status_code == 302
@@ -354,24 +354,24 @@ def test_project_list_oidc_needs_login(client):
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_RP_CLIENT_ID="test_client_id")
-def test_project_list_oidc_logged_in(client, user_without_permissions):
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_project_list_with_user(client, user_without_permissions):
     url = reverse("projects:project_list")
     response = client.get(url)
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_RP_CLIENT_ID=None)
-def test_project_detail_no_login(client, project):
+@override_settings(FORCE_LOGIN=False)
+def test_no_login_project_detail(client, project):
     url = reverse("projects:project", kwargs={"id": project.id})
     response = client.get(url)
     assert response.status_code == 200
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_RP_CLIENT_ID="test_client_id")
-def test_project_detail_oidc_needs_login(client, project):
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_project_detail(client, project):
     url = reverse("projects:project", kwargs={"id": project.id})
     response = client.get(url)
     assert response.status_code == 302
@@ -380,8 +380,8 @@ def test_project_detail_oidc_needs_login(client, project):
 
 
 @pytest.mark.django_db
-@override_settings(OIDC_RP_CLIENT_ID="test_client_id")
-def test_project_detail_oidc_logged_in(client, user_without_permissions, project):
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_project_detail_with_user(client, user_without_permissions, project):
     url = reverse("projects:project", kwargs={"id": project.id})
     response = client.get(url)
     assert response.status_code == 200

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -97,6 +97,8 @@ LOGGING = {
     },
 }
 
+FORCE_LOGIN = os.environ.get("DJANGO_FORCE_LOGIN", "false").lower() == "true"
+
 # OIDC Settings
 OIDC_RP_CLIENT_ID = os.environ.get("DJANGO_OIDC_CLIENT_ID")
 OIDC_RP_CLIENT_SECRET = os.environ.get("DJANGO_OIDC_CLIENT_SECRET")

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@ name: dashboard
 # see https://documentation.ubuntu.com/rockcraft/en/1.8.0/explanation/bases/
 # for more information about bases and using 'bare' bases for chiselled rocks
 base: ubuntu@22.04 # the base environment for this Django application
-version: "0.54" # just for humans. Semantic versioning is recommended
+version: "0.55" # just for humans. Semantic versioning is recommended
 summary: A summary of your Django application # 79 char long summary
 description: |
   Dashboard is a Django application to track quality and progress of multiple


### PR DESCRIPTION
This PR adds a `FORCE_LOGIN` setting that controls whether the app requires login to view the project list and project detail pages.

We currently determine this by checking whether OIDC is configured, but that has a problem in our production deployment: If the integration with `oauth-external-idp-integrator` is missing, users can view the application without logging in - which we don't want.

The new `FORCE_LOGIN` setting is controlled by an environment variable called `DJANGO_FORCE_LOGIN`. In the charmed application, this is controlled by a config option called `force-login`.

---

### Manual checks

- [x] If you changed the Dashboard application or the rock, have you increased the version number in `rockcraft.yaml`? Remember to use the same version number in `README.md`.
