### PR TITLE
Completely reworked the browser tests

### DIFF
--- a/dashboard/Makefile
+++ b/dashboard/Makefile
@@ -76,7 +76,7 @@ test-framework: install-dev
 test-projects: install-dev
 	$(PYTEST) projects
 
-]test-browser: install-dev
+test-browser: install-dev
 	$(VENV)/bin/python -m playwright install
 	$(PYTEST) test_browser.py
 

--- a/dashboard/test_browser.py
+++ b/dashboard/test_browser.py
@@ -403,7 +403,7 @@ def test_status(
     assert has_red.projectobjective().status is None
     expect(
         page.get_by_test_id(f"projectobjective_status_{projectobjective.id}")
-    ).to_contain_text("")
+    ).to_have_text("")
 
     for condition_key in condition_keys:
         check_condition_for_status(
@@ -420,7 +420,7 @@ def test_status(
     )
     expect(
         page.get_by_test_id(f"projectobjective_status_{projectobjective.id}")
-    ).to_contain_text(status_text)
+    ).to_have_text(status_text)
 
 
 def csv_from_commitment_table(page):

--- a/dashboard/test_browser.py
+++ b/dashboard/test_browser.py
@@ -292,10 +292,16 @@ def test_toggling_conditions(
     condition = getattr(browser_test_data, condition_key)
     assert condition.status == initial_status
 
+    projectobjective = condition.projectobjective()
+
     toggle = page.get_by_test_id(f"toggle_condition_{condition.id}")
     expect(toggle).to_be_visible()
-    with page.expect_response(
-        f"**/action_toggle_condition/{condition.id}?status={initial_status}&target=done"
+    with (
+        page.expect_response(
+            f"**/action_toggle_condition/{condition.id}?status={initial_status}&target=done"
+        ),
+        page.expect_response(f"**/status_projectobjective/{projectobjective.id}"),
+        page.expect_response(f"**/status_projects_commitment/{project.id}"),
     ):
         getattr(toggle, toggle_action)()
 
@@ -343,15 +349,21 @@ def test_toggling_commitments(
 
     toggle = page.get_by_test_id(f"toggle_commitment_{commitment.id}")
     expect(toggle).to_be_visible()
-    with page.expect_response(f"**/action_toggle_commitment/{commitment.id}"):
+    with (
+        page.expect_response(f"**/action_toggle_commitment/{commitment.id}"),
+        page.expect_response(f"**/status_projects_commitment/{project.id}"),
+    ):
         getattr(toggle, toggle_action)()
 
     commitment.refresh_from_db()
     assert commitment.committed is target_committed
 
 
-def check_condition_for_status(page, projectobjective_id, condition_id):
-    with page.expect_response(f"**/status_projectobjective/{projectobjective_id}"):
+def check_condition_for_status(page, projectobjective_id, condition_id, project_id):
+    with (
+        page.expect_response(f"**/status_projectobjective/{projectobjective_id}"),
+        page.expect_response(f"**/status_projects_commitment/{project_id}"),
+    ):
         page.get_by_test_id(f"toggle_condition_{condition_id}").check()
 
 
@@ -395,7 +407,10 @@ def test_status(
 
     for condition_key in condition_keys:
         check_condition_for_status(
-            page, projectobjective.id, getattr(browser_test_data, condition_key).id
+            page,
+            projectobjective.id,
+            getattr(browser_test_data, condition_key).id,
+            project.id,
         )
 
     final_condition = getattr(browser_test_data, condition_keys[-1])
@@ -437,8 +452,16 @@ def apply_commitment_table_operation(page, project_id, browser_test_data, operat
     obj = getattr(browser_test_data, data_key)
     toggle_kind = "condition" if operation_type == "condition" else "commitment"
 
-    with page.expect_response(f"**/status_projects_commitment/{project_id}"):
-        page.get_by_test_id(f"toggle_{toggle_kind}_{obj.id}").check()
+    if operation_type == "condition":
+        projectobjective_id = obj.projectobjective().id
+        with (
+            page.expect_response(f"**/status_projects_commitment/{project_id}"),
+            page.expect_response(f"**/status_projectobjective/{projectobjective_id}"),
+        ):
+            page.get_by_test_id(f"toggle_{toggle_kind}_{obj.id}").check()
+    else:
+        with page.expect_response(f"**/status_projects_commitment/{project_id}"):
+            page.get_by_test_id(f"toggle_{toggle_kind}_{obj.id}").check()
 
 
 @pytest.mark.parametrize(

--- a/dashboard/test_browser.py
+++ b/dashboard/test_browser.py
@@ -347,7 +347,7 @@ def test_toggling_commitments(
     page.goto(project_url(live_server, project))
 
     commitment = getattr(browser_test_data, commitment_key)
-    assert Commitment.objects.get(pk=commitment.pk).committed is initial_committed
+    assert Commitment.objects.get(pk=commitment.pk).committed == initial_committed
 
     toggle = page.get_by_test_id(f"toggle_commitment_{commitment.id}")
     expect(toggle).to_be_visible()
@@ -358,7 +358,7 @@ def test_toggling_commitments(
         getattr(toggle, toggle_action)()
 
     commitment.refresh_from_db()
-    assert commitment.committed is target_committed
+    assert commitment.committed == target_committed
 
 
 def check_condition_for_status(page, projectobjective_id, condition_id, project_id):

--- a/dashboard/test_browser.py
+++ b/dashboard/test_browser.py
@@ -242,12 +242,8 @@ def browser_test_data(transactional_db):
     )
 
 
-def project_url(live_server, project, anchor=None):
-    # Tabs are hash-based; objective controls are only visible when their tab is active.
-    url = f"{live_server.url}{reverse('projects:project', None, [project.id])}"
-    if anchor:
-        return f"{url}#{anchor}"
-    return url
+def project_url(live_server, project):
+    return f"{live_server.url}{reverse('projects:project', None, [project.id])}"
 
 
 @pytest.fixture
@@ -291,8 +287,7 @@ def test_toggling_conditions(
     # Check that condition toggles persist each status transition.
 
     project = browser_test_data.project
-    # Open the objective tab that contains the condition toggles used in this test.
-    page.goto(project_url(live_server, project, "agreeableness"))
+    page.goto(project_url(live_server, project))
 
     condition = getattr(browser_test_data, condition_key)
     assert condition.status == initial_status
@@ -341,8 +336,7 @@ def test_toggling_commitments(
     # Check that commitment toggles persist each committed-state transition.
 
     project = browser_test_data.project
-    # Open the objective tab that contains commitment toggles for Agreeableness.
-    page.goto(project_url(live_server, project, "agreeableness"))
+    page.goto(project_url(live_server, project))
 
     commitment = getattr(browser_test_data, commitment_key)
     assert commitment.committed is initial_committed
@@ -389,8 +383,7 @@ def test_status(
 
     project = browser_test_data.project
     projectobjective = browser_test_data.colourfulness_projectobjective
-    # Activate the Colourfulness tab so the condition controls are interactable.
-    page.goto(project_url(live_server, project, "colourfulness"))
+    page.goto(project_url(live_server, project))
 
     has_red = browser_test_data.poc_has_red
     assert has_red.projectobjective().project == project
@@ -513,8 +506,6 @@ def test_commitment_table(
     page.goto(project_url(live_server, project))
 
     if operations:
-        # Switch to the objective tab to trigger updates that refresh the summary table.
-        page.goto(project_url(live_server, project, "colourfulness"))
         for operation in operations:
             apply_commitment_table_operation(
                 page, project.id, browser_test_data, operation

--- a/dashboard/test_browser.py
+++ b/dashboard/test_browser.py
@@ -1,191 +1,529 @@
-import textwrap
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
 
 import pytest
 
 from playwright.sync_api import expect
 
-from django.core.management import call_command
-from django.urls import reverse
 from django.conf import settings
+from django.contrib.auth.models import User
+from django.urls import reverse
 
-from projects.models import (
-    ProjectObjectiveCondition,
-    Commitment,
-)
-
-from framework.models import Level
+from framework.models import Condition, Level, Objective, ObjectiveGroup, WorkCycle
+from projects.models import Commitment, Project, ProjectObjectiveCondition
 
 
-# Our tests use 'live_server', so we populate the database every time a test starts.
-# See https://pytest-django.readthedocs.io/en/latest/database.html#populate-the-test-database-if-you-use-transactional-or-live-server
-#
-# We define a custom 'page' fixture that depends on 'live_server' and Playwright's 'page' fixture.
-# Since 'live_server' depends on 'transactional_db', we don't need to explicitly mark our tests as
-# @pytest.mark.django_db(transaction=True) or have our tests depend on 'transactional_db'.
-
-
-@pytest.fixture(scope="function")
-def django_db_setup(django_db_setup, django_db_blocker):
-    with django_db_blocker.unblock():
-        call_command("loaddata", "initial_data.yaml")
+@dataclass(frozen=True)
+class BrowserTestData:
+    project: Project
+    level_started: Level
+    level_first_results: Level
+    colourfulness_projectobjective: Any
+    poc_speaks_pleasantly: ProjectObjectiveCondition
+    poc_accepts_praise: ProjectObjectiveCondition
+    poc_has_red: ProjectObjectiveCondition
+    poc_is_striated: ProjectObjectiveCondition
+    poc_is_dappled: ProjectObjectiveCondition
+    commitment_agree_started_2022: Commitment
+    commitment_agree_started_2025: Commitment
+    commitment_colour_first_results_2026: Commitment
 
 
 @pytest.fixture
-def page(page, client, live_server):
-    """Provides a Playwright `Page` that is logged in to a project page in Django's live server."""
+def browser_test_data(transactional_db):
+    # Create the smallest object graph needed by the browser tests.
 
-    # Use Django's mock client to simulate a login and capture the session cookie.
+    User.objects.create_superuser("superuser", "superuser@example.com", "superuser")
+
+    level_started = Level.objects.create(name="Started", value=1)
+    level_first_results = Level.objects.create(name="First results", value=2)
+
+    group_human = ObjectiveGroup.objects.create(name="Human friendliness")
+    group_physical = ObjectiveGroup.objects.create(name="Physical characteristics")
+
+    objective_agreeableness = Objective.objects.create(
+        name="Agreeableness", group=group_human, weight=1
+    )
+    objective_colourfulness = Objective.objects.create(
+        name="Colourfulness", group=group_physical, weight=1
+    )
+    objective_handling = Objective.objects.create(
+        name="Handling", group=group_human, weight=1
+    )
+
+    condition_speaks_pleasantly = Condition.objects.create(
+        name="Speaks pleasantly",
+        objective=objective_agreeableness,
+        level=level_started,
+    )
+    condition_accepts_praise = Condition.objects.create(
+        name="Accepts praise and thanks with grace",
+        objective=objective_agreeableness,
+        level=level_first_results,
+    )
+
+    condition_has_blue = Condition.objects.create(
+        name="Has blue",
+        objective=objective_colourfulness,
+        level=level_started,
+    )
+    condition_has_green = Condition.objects.create(
+        name="Has green",
+        objective=objective_colourfulness,
+        level=level_started,
+    )
+    condition_has_red = Condition.objects.create(
+        name="Has red",
+        objective=objective_colourfulness,
+        level=level_started,
+    )
+    condition_is_striated = Condition.objects.create(
+        name="Is striated",
+        objective=objective_colourfulness,
+        level=level_first_results,
+    )
+    condition_is_dappled = Condition.objects.create(
+        name="Is dappled",
+        objective=objective_colourfulness,
+        level=level_first_results,
+    )
+
+    condition_handles_safely = Condition.objects.create(
+        name="Handles safely",
+        objective=objective_handling,
+        level=level_started,
+    )
+
+    workcycle_2022 = WorkCycle.objects.create(
+        name="2022", timestamp=date(2022, 1, 1), is_current=False
+    )
+    workcycle_2025 = WorkCycle.objects.create(
+        name="2025", timestamp=date(2025, 1, 1), is_current=False
+    )
+    workcycle_2026 = WorkCycle.objects.create(
+        name="2026", timestamp=date(2026, 1, 1), is_current=True
+    )
+
+    project = Project.objects.create(
+        name="Test Project", last_review=date(2024, 12, 16)
+    )
+
+    poc_speaks_pleasantly = ProjectObjectiveCondition.objects.get(
+        project=project,
+        objective=objective_agreeableness,
+        condition=condition_speaks_pleasantly,
+    )
+    poc_accepts_praise = ProjectObjectiveCondition.objects.get(
+        project=project,
+        objective=objective_agreeableness,
+        condition=condition_accepts_praise,
+    )
+    poc_has_blue = ProjectObjectiveCondition.objects.get(
+        project=project,
+        objective=objective_colourfulness,
+        condition=condition_has_blue,
+    )
+    poc_has_green = ProjectObjectiveCondition.objects.get(
+        project=project,
+        objective=objective_colourfulness,
+        condition=condition_has_green,
+    )
+    poc_has_red = ProjectObjectiveCondition.objects.get(
+        project=project,
+        objective=objective_colourfulness,
+        condition=condition_has_red,
+    )
+    poc_is_striated = ProjectObjectiveCondition.objects.get(
+        project=project,
+        objective=objective_colourfulness,
+        condition=condition_is_striated,
+    )
+    poc_is_dappled = ProjectObjectiveCondition.objects.get(
+        project=project,
+        objective=objective_colourfulness,
+        condition=condition_is_dappled,
+    )
+    poc_handles_safely = ProjectObjectiveCondition.objects.get(
+        project=project,
+        objective=objective_handling,
+        condition=condition_handles_safely,
+    )
+
+    # Set only the statuses needed by test expectations.
+    poc_speaks_pleasantly.status = "DO"
+    poc_accepts_praise.status = ""
+    poc_has_blue.status = "DO"
+    poc_has_green.status = "DO"
+    poc_has_red.status = ""
+    poc_is_striated.status = ""
+    poc_is_dappled.status = ""
+    poc_handles_safely.status = "DO"
+    for poc in (
+        poc_speaks_pleasantly,
+        poc_accepts_praise,
+        poc_has_blue,
+        poc_has_green,
+        poc_has_red,
+        poc_is_striated,
+        poc_is_dappled,
+        poc_handles_safely,
+    ):
+        poc.save(update_fields=["status"])
+
+    commitment_agree_started_2022 = Commitment.objects.get(
+        project=project,
+        objective=objective_agreeableness,
+        level=level_started,
+        work_cycle=workcycle_2022,
+    )
+    commitment_agree_started_2025 = Commitment.objects.get(
+        project=project,
+        objective=objective_agreeableness,
+        level=level_started,
+        work_cycle=workcycle_2025,
+    )
+    commitment_agree_started_2026 = Commitment.objects.get(
+        project=project,
+        objective=objective_agreeableness,
+        level=level_started,
+        work_cycle=workcycle_2026,
+    )
+    commitment_colour_started_2026 = Commitment.objects.get(
+        project=project,
+        objective=objective_colourfulness,
+        level=level_started,
+        work_cycle=workcycle_2026,
+    )
+    commitment_colour_first_results_2026 = Commitment.objects.get(
+        project=project,
+        objective=objective_colourfulness,
+        level=level_first_results,
+        work_cycle=workcycle_2026,
+    )
+    commitment_handling_started_2026 = Commitment.objects.get(
+        project=project,
+        objective=objective_handling,
+        level=level_started,
+        work_cycle=workcycle_2026,
+    )
+
+    commitment_agree_started_2022.committed = False
+    commitment_agree_started_2025.committed = True
+    commitment_agree_started_2026.committed = True
+    commitment_colour_started_2026.committed = True
+    commitment_colour_first_results_2026.committed = False
+    commitment_handling_started_2026.committed = True
+    for commitment in (
+        commitment_agree_started_2022,
+        commitment_agree_started_2025,
+        commitment_agree_started_2026,
+        commitment_colour_started_2026,
+        commitment_colour_first_results_2026,
+        commitment_handling_started_2026,
+    ):
+        commitment.save(update_fields=["committed"])
+
+    colourfulness_projectobjective = poc_has_red.projectobjective()
+
+    return BrowserTestData(
+        project=project,
+        level_started=level_started,
+        level_first_results=level_first_results,
+        colourfulness_projectobjective=colourfulness_projectobjective,
+        poc_speaks_pleasantly=poc_speaks_pleasantly,
+        poc_accepts_praise=poc_accepts_praise,
+        poc_has_red=poc_has_red,
+        poc_is_striated=poc_is_striated,
+        poc_is_dappled=poc_is_dappled,
+        commitment_agree_started_2022=commitment_agree_started_2022,
+        commitment_agree_started_2025=commitment_agree_started_2025,
+        commitment_colour_first_results_2026=commitment_colour_first_results_2026,
+    )
+
+
+def project_url(live_server, project, anchor=None):
+    # Tabs are hash-based; objective controls are only visible when their tab is active.
+    url = f"{live_server.url}{reverse('projects:project', None, [project.id])}"
+    if anchor:
+        return f"{url}#{anchor}"
+    return url
+
+
+@pytest.fixture
+def page(page, client, live_server, browser_test_data):
+    # Provide a Playwright page logged in to Django's live server.
+
     client.login(username="superuser", password="superuser")
     cookie = client.cookies[settings.SESSION_COOKIE_NAME]
 
-    # Inject the session cookie into the browser page.
-    page.context.add_cookies([
-        {
-            "name": settings.SESSION_COOKIE_NAME,
-            "value": cookie.value,
-            "url": live_server.url,
-        }
-    ])
-
-    # Navigate the page to the Nuclear project in the live server.
-    project_id = 1
-    url_end = reverse("projects:project", None, [project_id])
-    page.goto(f"{live_server.url}{url_end}")
+    page.context.add_cookies(
+        [
+            {
+                "name": settings.SESSION_COOKIE_NAME,
+                "value": cookie.value,
+                "url": live_server.url,
+            }
+        ]
+    )
 
     yield page
 
 
-def test_toggling_conditions(page):
-    """Check that conditions can be toggled and saved in the database."""
+@pytest.mark.parametrize(
+    "condition_key,initial_status,target_status,toggle_action",
+    [
+        # A condition already marked as done can be unset.
+        pytest.param("poc_speaks_pleasantly", "DO", "", "uncheck", id="done-to-empty"),
+        # A previously unset condition can be marked as done.
+        pytest.param("poc_accepts_praise", "", "DO", "check", id="empty-to-done"),
+    ],
+)
+def test_toggling_conditions(
+    page,
+    live_server,
+    browser_test_data,
+    condition_key,
+    initial_status,
+    target_status,
+    toggle_action,
+):
+    # Check that condition toggles persist each status transition.
 
-    assert ProjectObjectiveCondition.objects.count() == 1752
+    project = browser_test_data.project
+    # Open the objective tab that contains the condition toggles used in this test.
+    page.goto(project_url(live_server, project, "agreeableness"))
 
-    # Toggle project objective condition:
-    # Nuclear > Agreeableness > Started > Speaks pleasantly
-    assert ProjectObjectiveCondition.objects.get(id=94).status == "DO"
-    with page.expect_response("**/action_toggle_condition/94?status=DO&target=done"):
-        page.get_by_test_id("toggle_condition_94").uncheck()
-    assert ProjectObjectiveCondition.objects.get(id=94).status == ""
+    condition = getattr(browser_test_data, condition_key)
+    assert condition.status == initial_status
 
-    # Toggle project objective condition:
-    # Nuclear > Agreeableness > First results > Accepts praise and thanks with grace
-    assert ProjectObjectiveCondition.objects.get(id=102).status == ""
-    with page.expect_response("**/action_toggle_condition/102?status=&target=done"):
-        page.get_by_test_id("toggle_condition_102").check()
-    assert ProjectObjectiveCondition.objects.get(id=102).status == "DO"
+    toggle = page.get_by_test_id(f"toggle_condition_{condition.id}")
+    expect(toggle).to_be_visible()
+    with page.expect_response(
+        f"**/action_toggle_condition/{condition.id}?status={initial_status}&target=done"
+    ):
+        getattr(toggle, toggle_action)()
 
-
-def test_toggling_commitments(page):
-    """Check that commitments can be toggled and saved in the database."""
-
-    # Toggle commitment:
-    # Nuclear > Agreeableness > Started > 2022
-    assert not Commitment.objects.get(id=705).committed
-    with page.expect_response("**/action_toggle_commitment/705"):
-        page.get_by_test_id("toggle_commitment_705").check()
-    assert Commitment.objects.get(id=705).committed
-
-    # Toggle commitment:
-    # Nuclear > Agreeableness > Started > 2025
-    assert Commitment.objects.get(id=474).committed
-    with page.expect_response("**/action_toggle_commitment/474"):
-        page.get_by_test_id("toggle_commitment_474").uncheck()
-    assert not Commitment.objects.get(id=474).committed
+    condition.refresh_from_db()
+    assert condition.status == target_status
 
 
-def test_status(page):
-    """Check that objective status is correctly updated based on conditions."""
+@pytest.mark.parametrize(
+    "commitment_key,initial_committed,toggle_action,target_committed",
+    [
+        # A not-yet committed level can be committed.
+        pytest.param(
+            "commitment_agree_started_2022",
+            False,
+            "check",
+            True,
+            id="uncommitted-to-committed",
+        ),
+        # An already committed level can be uncommitted.
+        pytest.param(
+            "commitment_agree_started_2025",
+            True,
+            "uncheck",
+            False,
+            id="committed-to-uncommitted",
+        ),
+    ],
+)
+def test_toggling_commitments(
+    page,
+    live_server,
+    browser_test_data,
+    commitment_key,
+    initial_committed,
+    toggle_action,
+    target_committed,
+):
+    # Check that commitment toggles persist each committed-state transition.
 
-    # Check that the expected conditions and status are represented on the page.
-    # The project objective conditions are under Nuclear > Colourfulness:
-    # ------ Started ------
-    # 1   Has blue
-    # 6   Has green
-    # 10  Has red
-    # --- First results ---
-    # 14  Is striated
-    # 18  Is dappled
-    # ---------------------
-    assert ProjectObjectiveCondition.objects.get(id=1).status == "DO"
-    assert ProjectObjectiveCondition.objects.get(id=6).status == "DO"
-    assert ProjectObjectiveCondition.objects.get(id=10).status == ""
-    assert (
-        ProjectObjectiveCondition.objects.get(id=10).projectobjective().status is None
+    project = browser_test_data.project
+    # Open the objective tab that contains commitment toggles for Agreeableness.
+    page.goto(project_url(live_server, project, "agreeableness"))
+
+    commitment = getattr(browser_test_data, commitment_key)
+    assert commitment.committed is initial_committed
+
+    toggle = page.get_by_test_id(f"toggle_commitment_{commitment.id}")
+    expect(toggle).to_be_visible()
+    with page.expect_response(f"**/action_toggle_commitment/{commitment.id}"):
+        getattr(toggle, toggle_action)()
+
+    commitment.refresh_from_db()
+    assert commitment.committed is target_committed
+
+
+def check_condition_for_status(page, projectobjective_id, condition_id):
+    with page.expect_response(f"**/status_projectobjective/{projectobjective_id}"):
+        page.get_by_test_id(f"toggle_condition_{condition_id}").check()
+
+
+@pytest.mark.parametrize(
+    "condition_keys,status_level_key,status_text",
+    [
+        # Meeting the first-level condition sets status to Started.
+        pytest.param(
+            ["poc_has_red"], "level_started", "Started", id="reach-started-level"
+        ),
+        # Meeting all first-results conditions raises status to First results.
+        pytest.param(
+            ["poc_has_red", "poc_is_striated", "poc_is_dappled"],
+            "level_first_results",
+            "First results",
+            id="reach-first-results-level",
+        ),
+    ],
+)
+def test_status(
+    page,
+    live_server,
+    browser_test_data,
+    condition_keys,
+    status_level_key,
+    status_text,
+):
+    # Check that objective status follows the highest reached level.
+
+    project = browser_test_data.project
+    projectobjective = browser_test_data.colourfulness_projectobjective
+    # Activate the Colourfulness tab so the condition controls are interactable.
+    page.goto(project_url(live_server, project, "colourfulness"))
+
+    has_red = browser_test_data.poc_has_red
+    assert has_red.projectobjective().project == project
+    assert has_red.status == ""
+    assert has_red.projectobjective().status is None
+    expect(
+        page.get_by_test_id(f"projectobjective_status_{projectobjective.id}")
+    ).to_contain_text("")
+
+    for condition_key in condition_keys:
+        check_condition_for_status(
+            page, projectobjective.id, getattr(browser_test_data, condition_key).id
+        )
+
+    final_condition = getattr(browser_test_data, condition_keys[-1])
+    final_condition.refresh_from_db()
+    assert final_condition.projectobjective().status == getattr(
+        browser_test_data, status_level_key
     )
-    expect(page.get_by_test_id("projectobjective_status_1")).to_contain_text("")
-
-    # Toggle the remaining condition (Has red) to get to Started.
-    with page.expect_response("**/status_projectobjective/1"):
-        page.get_by_test_id("toggle_condition_10").check()
-    assert ProjectObjectiveCondition.objects.get(
-        id=10
-    ).projectobjective().status == Level.objects.get(id=1)
-    expect(page.get_by_test_id("projectobjective_status_1")).to_contain_text("Started")
-
-    # Toggle two more conditions (Is striated, Is dappled) to get to First results.
-    with page.expect_response("**/status_projectobjective/1"):
-        page.get_by_test_id("toggle_condition_14").check()
-    with page.expect_response("**/status_projectobjective/1"):
-        page.get_by_test_id("toggle_condition_18").check()
-    assert ProjectObjectiveCondition.objects.get(
-        id=18
-    ).projectobjective().status == Level.objects.get(id=2)
-    expect(page.get_by_test_id("projectobjective_status_1")).to_contain_text(
-        "First results"
-    )
+    expect(
+        page.get_by_test_id(f"projectobjective_status_{projectobjective.id}")
+    ).to_contain_text(status_text)
 
 
 def csv_from_commitment_table(page):
-    """Convert the "Commitments for <cycle>" table to CSV."""
+    # Convert the commitments table to CSV.
     row_text = []
-    rows = page.query_selector_all("table#commitment-table tr")
-    for row in rows[1:]:
+    rows = page.locator("table#commitment-table tr")
+    for row_index in range(1, rows.count()):
+        row = rows.nth(row_index)
         row_values = []
-        for cell in row.query_selector_all("td"):
-            checkbox = cell.query_selector("input[type='checkbox']")
-            if checkbox:
+        cells = row.locator("td")
+        for cell_index in range(cells.count()):
+            cell = cells.nth(cell_index)
+            checkbox = cell.locator("input[type='checkbox']")
+            if checkbox.count() > 0:
                 row_values.append("Y" if checkbox.is_checked() else "N")
             else:
-                row_values.append(cell.text_content().strip())
+                row_values.append(cell.inner_text().strip())
         row_text.append(",".join(row_values))
     return "\n".join(row_text)
 
 
-def test_commitment_table(page):
-    """Check that "Commitments for <cycle>" updates when commitments, unstarted reason, and conditions are changed."""
-    # The table's columns are: Objective, Target, Achieved (checkbox).
-    # We're using Y/N to represent whether the checkbox is checked.
-    assert csv_from_commitment_table(page) == textwrap.dedent("""\
-        Agreeableness,Started,Y
-        Colourfulness,Started,N
-        Handling,Started,Y""")
-    # Toggle Colourfulness > First results > 2026.
-    with page.expect_response("**/status_projects_commitment/1"):
-        page.get_by_test_id("toggle_commitment_3170").check()
-    assert csv_from_commitment_table(page) == textwrap.dedent("""\
-        Agreeableness,Started,Y
-        Colourfulness,Started,N
-        Colourfulness,First results,N
-        Handling,Started,Y""")
-    # Toggle Colourfulness > Started > Has red.
-    with page.expect_response("**/status_projects_commitment/1"):
-        page.get_by_test_id("toggle_condition_10").check()
-    assert csv_from_commitment_table(page) == textwrap.dedent("""\
-        Agreeableness,Started,Y
-        Colourfulness,Started,Y
-        Colourfulness,First results,N
-        Handling,Started,Y""")
-    # Toggle Colourfulness > First results > all conditions.
-    with page.expect_response("**/status_projects_commitment/1"):
-        page.get_by_test_id("toggle_condition_14").check()
-    with page.expect_response("**/status_projects_commitment/1"):
-        page.get_by_test_id("toggle_condition_18").check()
-    assert csv_from_commitment_table(page) == textwrap.dedent("""\
-        Agreeableness,Started,Y
-        Colourfulness,Started,Y
-        Colourfulness,First results,Y
-        Handling,Started,Y""")
+def assert_commitment_table_rows(page, expected_rows):
+    actual_rows = csv_from_commitment_table(page).splitlines()
+    assert sorted(actual_rows) == sorted(expected_rows)
 
 
-def test_last_review(page):
-    expect(page.get_by_role("textbox", name="Last review:")).to_have_value("2024-12-16")
+def apply_commitment_table_operation(page, project_id, browser_test_data, operation):
+    operation_type, data_key = operation
+    obj = getattr(browser_test_data, data_key)
+    toggle_kind = "condition" if operation_type == "condition" else "commitment"
+
+    with page.expect_response(f"**/status_projects_commitment/{project_id}"):
+        page.get_by_test_id(f"toggle_{toggle_kind}_{obj.id}").check()
+
+
+@pytest.mark.parametrize(
+    "operations,expected_rows",
+    [
+        # Baseline overview before additional interaction.
+        pytest.param(
+            [],
+            [
+                "Agreeableness,Started,Y",
+                "Colourfulness,Started,N",
+                "Handling,Started,Y",
+            ],
+            id="baseline-overview",
+        ),
+        # Adding a first-results commitment adds a new row, still unmet.
+        pytest.param(
+            [("commitment", "commitment_colour_first_results_2026")],
+            [
+                "Agreeableness,Started,Y",
+                "Colourfulness,Started,N",
+                "Colourfulness,First results,N",
+                "Handling,Started,Y",
+            ],
+            id="first-results-commitment-added",
+        ),
+        # Once Has red is done, Started is met while First results is still unmet.
+        pytest.param(
+            [
+                ("commitment", "commitment_colour_first_results_2026"),
+                ("condition", "poc_has_red"),
+            ],
+            [
+                "Agreeableness,Started,Y",
+                "Colourfulness,Started,Y",
+                "Colourfulness,First results,N",
+                "Handling,Started,Y",
+            ],
+            id="started-level-now-met",
+        ),
+        # After all first-results conditions are done, First results also becomes met.
+        pytest.param(
+            [
+                ("commitment", "commitment_colour_first_results_2026"),
+                ("condition", "poc_has_red"),
+                ("condition", "poc_is_striated"),
+                ("condition", "poc_is_dappled"),
+            ],
+            [
+                "Agreeableness,Started,Y",
+                "Colourfulness,Started,Y",
+                "Colourfulness,First results,Y",
+                "Handling,Started,Y",
+            ],
+            id="first-results-level-now-met",
+        ),
+    ],
+)
+def test_commitment_table(
+    page, live_server, browser_test_data, operations, expected_rows
+):
+    # Check that commitment summary rows reflect the current toggled state.
+
+    project = browser_test_data.project
+    page.goto(project_url(live_server, project))
+
+    if operations:
+        # Switch to the objective tab to trigger updates that refresh the summary table.
+        page.goto(project_url(live_server, project, "colourfulness"))
+        for operation in operations:
+            apply_commitment_table_operation(
+                page, project.id, browser_test_data, operation
+            )
+
+    assert_commitment_table_rows(page, expected_rows)
+
+
+def test_last_review(page, live_server, browser_test_data):
+    project = browser_test_data.project
+    page.goto(project_url(live_server, project))
+    expect(page.locator("#id_last_review")).to_have_value("2024-12-16")

--- a/dashboard/test_browser.py
+++ b/dashboard/test_browser.py
@@ -290,7 +290,9 @@ def test_toggling_conditions(
     page.goto(project_url(live_server, project))
 
     condition = getattr(browser_test_data, condition_key)
-    assert condition.status == initial_status
+    assert (
+        ProjectObjectiveCondition.objects.get(pk=condition.pk).status == initial_status
+    )
 
     projectobjective = condition.projectobjective()
 
@@ -345,7 +347,7 @@ def test_toggling_commitments(
     page.goto(project_url(live_server, project))
 
     commitment = getattr(browser_test_data, commitment_key)
-    assert commitment.committed is initial_committed
+    assert Commitment.objects.get(pk=commitment.pk).committed is initial_committed
 
     toggle = page.get_by_test_id(f"toggle_commitment_{commitment.id}")
     expect(toggle).to_be_visible()

--- a/dashboard/test_browser.py
+++ b/dashboard/test_browser.py
@@ -416,7 +416,6 @@ def test_status(
         )
 
     final_condition = getattr(browser_test_data, condition_keys[-1])
-    final_condition.refresh_from_db()
     assert final_condition.projectobjective().status == getattr(
         browser_test_data, status_level_key
     )


### PR DESCRIPTION
Cherry-picked from https://github.com/canonical/dashboard/pull/160

---

Previously this depended on the initial_data.yaml fixture, which was a bit fragile. Now it sets up the required data in the test itself; the test file's a lot harder to read but perhaos it makes sense like this.

This is almost entirely Copilot's handiwork.