### PR TITLE
Adjust OIDC callback URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The application will run in a Kubernetes cluster, so we need a container image f
 Creating the container image might take several minutes, so this is a good point to take a break. When you return, you should see the following output:
 
 > ```
-> Packed dashboard_0.56_amd64.rock
+> Packed dashboard_0.57_amd64.rock
 > ```
 
 ### Create a charm
@@ -109,10 +109,10 @@ Creating the charm might take several minutes, so this is another good point to 
 ``` { name=deploy-dashboard }
 cd ~/dashboard
 rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-  oci-archive:dashboard_0.56_amd64.rock \
-  docker://localhost:32000/dashboard:0.56
+  oci-archive:dashboard_0.57_amd64.rock \
+  docker://localhost:32000/dashboard:0.57
 juju deploy ./charm/dashboard_ubuntu-22.04-amd64.charm \
-  --resource django-app-image=localhost:32000/dashboard:0.56
+  --resource django-app-image=localhost:32000/dashboard:0.57
 ```
 
 The `rockcraft.skopeo` command makes the container image available to Juju.

--- a/dashboard/dashboard/settings.py
+++ b/dashboard/dashboard/settings.py
@@ -83,7 +83,7 @@ OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
 OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USER_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
 
-# The callback path will be /oidc/callback - see dashboard/dashboard/urls.py
+# The callback path will be /oidc/callback/ - see dashboard/dashboard/urls.py
 
 # Optional OIDC Settings
 OIDC_RP_SCOPES = os.environ.get("DJANGO_OIDC_SCOPES", "openid email profile")

--- a/dashboard/dashboard/urls.py
+++ b/dashboard/dashboard/urls.py
@@ -10,7 +10,7 @@ urlpatterns = [
     
     # OIDC URLs
     path("oidc/authenticate", oidc_views.OIDCAuthenticationRequestView.as_view(), name="oidc_authentication_init"),
-    path("oidc/callback", oidc_views.OIDCAuthenticationCallbackView.as_view(), name="oidc_authentication_callback"),
+    path("oidc/callback/", oidc_views.OIDCAuthenticationCallbackView.as_view(), name="oidc_authentication_callback"),
     path("oidc/logout/", oidc_views.OIDCLogoutView.as_view(), name="oidc_logout"),
 
     # Dashboard

--- a/dashboard_rock_patch/dashboard/settings.py
+++ b/dashboard_rock_patch/dashboard/settings.py
@@ -107,7 +107,7 @@ OIDC_OP_TOKEN_ENDPOINT = os.environ.get("DJANGO_OIDC_ACCESS_TOKEN_URL")
 OIDC_OP_USER_ENDPOINT = os.environ.get("DJANGO_OIDC_USER_URL")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("DJANGO_OIDC_JWKS_URL")
 
-# The callback path will be /oidc/callback - see dashboard/dashboard/urls.py
+# The callback path will be /oidc/callback/ - see dashboard/dashboard/urls.py
 
 # Optional OIDC Settings
 OIDC_RP_SCOPES = os.environ.get("DJANGO_OIDC_SCOPES", "openid email profile")

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@ name: dashboard
 # see https://documentation.ubuntu.com/rockcraft/en/1.8.0/explanation/bases/
 # for more information about bases and using 'bare' bases for chiselled rocks
 base: ubuntu@22.04 # the base environment for this Django application
-version: "0.56" # just for humans. Semantic versioning is recommended
+version: "0.57" # just for humans. Semantic versioning is recommended
 summary: A summary of your Django application # 79 char long summary
 description: |
   Dashboard is a Django application to track quality and progress of multiple


### PR DESCRIPTION
This PR adds a trailing slash to the callback URL for consistency with our production IdP. Other IdPs would need to adjust accordingly.

---

### Manual checks

- [x] If you changed the Dashboard application or the rock, have you increased the version number in `rockcraft.yaml`? Remember to use the same version number in `README.md`.
