### PR TITLE
Prevent leaks from status endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The application will run in a Kubernetes cluster, so we need a container image f
 Creating the container image might take several minutes, so this is a good point to take a break. When you return, you should see the following output:
 
 > ```
-> Packed dashboard_0.57_amd64.rock
+> Packed dashboard_0.58_amd64.rock
 > ```
 
 ### Create a charm
@@ -109,10 +109,10 @@ Creating the charm might take several minutes, so this is another good point to 
 ``` { name=deploy-dashboard }
 cd ~/dashboard
 rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false \
-  oci-archive:dashboard_0.57_amd64.rock \
-  docker://localhost:32000/dashboard:0.57
+  oci-archive:dashboard_0.58_amd64.rock \
+  docker://localhost:32000/dashboard:0.58
 juju deploy ./charm/dashboard_ubuntu-22.04-amd64.charm \
-  --resource django-app-image=localhost:32000/dashboard:0.57
+  --resource django-app-image=localhost:32000/dashboard:0.58
 ```
 
 The `rockcraft.skopeo` command makes the container image available to Juju.

--- a/dashboard/projects/test_views.py
+++ b/dashboard/projects/test_views.py
@@ -407,39 +407,19 @@ def test_force_login_project_detail_with_user(
 
 @pytest.mark.django_db
 @override_settings(FORCE_LOGIN=False)
+def test_status_projects_commitment_returns_404_for_unknown_id(client):
+    url = reverse("projects:status_projects_commitment", kwargs={"project_id": 999999})
+    response = client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
 def test_no_login_status_projects_commitment(client, project):
     url = reverse(
         "projects:status_projects_commitment", kwargs={"project_id": project.id}
     )
-
     response = client.get(url)
-
-    assert response.status_code == 200
-
-
-@pytest.mark.django_db
-@override_settings(FORCE_LOGIN=False)
-def test_no_login_status_projectobjective(client, project_objective):
-    url = reverse(
-        "projects:status_projectobjective",
-        kwargs={"projectobjective_id": project_objective.id},
-    )
-
-    response = client.get(url)
-
-    assert response.status_code == 200
-
-
-@pytest.mark.django_db
-@override_settings(FORCE_LOGIN=False)
-def test_no_login_status_dashboardprojectobjective(client, project_objective):
-    url = reverse(
-        "projects:status_dashboardprojectobjective",
-        kwargs={"projectobjective_id": project_objective.id},
-    )
-
-    response = client.get(url)
-
     assert response.status_code == 200
 
 
@@ -449,37 +429,7 @@ def test_force_login_status_projects_commitment(client, project):
     url = reverse(
         "projects:status_projects_commitment", kwargs={"project_id": project.id}
     )
-
     response = client.get(url)
-
-    assert response.status_code == 302
-    assert response.url == f"{reverse('login')}?next={url}"
-
-
-@pytest.mark.django_db
-@override_settings(FORCE_LOGIN=True)
-def test_force_login_status_projectobjective(client, project_objective):
-    url = reverse(
-        "projects:status_projectobjective",
-        kwargs={"projectobjective_id": project_objective.id},
-    )
-
-    response = client.get(url)
-
-    assert response.status_code == 302
-    assert response.url == f"{reverse('login')}?next={url}"
-
-
-@pytest.mark.django_db
-@override_settings(FORCE_LOGIN=True)
-def test_force_login_status_dashboardprojectobjective(client, project_objective):
-    url = reverse(
-        "projects:status_dashboardprojectobjective",
-        kwargs={"projectobjective_id": project_objective.id},
-    )
-
-    response = client.get(url)
-
     assert response.status_code == 302
     assert response.url == f"{reverse('login')}?next={url}"
 
@@ -492,10 +442,42 @@ def test_force_login_status_projects_commitment_with_user(
     url = reverse(
         "projects:status_projects_commitment", kwargs={"project_id": project.id}
     )
-
     response = client.get(url)
-
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
+def test_status_projectobjective_returns_404_for_unknown_id(client):
+    url = reverse(
+        "projects:status_projectobjective",
+        kwargs={"projectobjective_id": 999999},
+    )
+    response = client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
+def test_no_login_status_projectobjective(client, project_objective):
+    url = reverse(
+        "projects:status_projectobjective",
+        kwargs={"projectobjective_id": project_objective.id},
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_status_projectobjective(client, project_objective):
+    url = reverse(
+        "projects:status_projectobjective",
+        kwargs={"projectobjective_id": project_objective.id},
+    )
+    response = client.get(url)
+    assert response.status_code == 302
+    assert response.url == f"{reverse('login')}?next={url}"
 
 
 @pytest.mark.django_db
@@ -514,6 +496,40 @@ def test_force_login_status_projectobjective_with_user(
 
 
 @pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
+def test_status_dashboardprojectobjective_returns_404_for_unknown_id(client):
+    url = reverse(
+        "projects:status_dashboardprojectobjective",
+        kwargs={"projectobjective_id": 999999},
+    )
+    response = client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
+def test_no_login_status_dashboardprojectobjective(client, project_objective):
+    url = reverse(
+        "projects:status_dashboardprojectobjective",
+        kwargs={"projectobjective_id": project_objective.id},
+    )
+    response = client.get(url)
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_status_dashboardprojectobjective(client, project_objective):
+    url = reverse(
+        "projects:status_dashboardprojectobjective",
+        kwargs={"projectobjective_id": project_objective.id},
+    )
+    response = client.get(url)
+    assert response.status_code == 302
+    assert response.url == f"{reverse('login')}?next={url}"
+
+
+@pytest.mark.django_db
 @override_settings(FORCE_LOGIN=True)
 def test_force_login_status_dashboardprojectobjective_with_user(
     client, user_without_permissions, project_objective
@@ -522,43 +538,5 @@ def test_force_login_status_dashboardprojectobjective_with_user(
         "projects:status_dashboardprojectobjective",
         kwargs={"projectobjective_id": project_objective.id},
     )
-
     response = client.get(url)
-
     assert response.status_code == 200
-
-
-@pytest.mark.django_db
-@override_settings(FORCE_LOGIN=False)
-def test_status_projects_commitment_returns_404_for_unknown_id(client):
-    url = reverse("projects:status_projects_commitment", kwargs={"project_id": 999999})
-
-    response = client.get(url)
-
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-@override_settings(FORCE_LOGIN=False)
-def test_status_projectobjective_returns_404_for_unknown_id(client):
-    url = reverse(
-        "projects:status_projectobjective",
-        kwargs={"projectobjective_id": 999999},
-    )
-
-    response = client.get(url)
-
-    assert response.status_code == 404
-
-
-@pytest.mark.django_db
-@override_settings(FORCE_LOGIN=False)
-def test_status_dashboardprojectobjective_returns_404_for_unknown_id(client):
-    url = reverse(
-        "projects:status_dashboardprojectobjective",
-        kwargs={"projectobjective_id": 999999},
-    )
-
-    response = client.get(url)
-
-    assert response.status_code == 404

--- a/dashboard/projects/test_views.py
+++ b/dashboard/projects/test_views.py
@@ -403,3 +403,162 @@ def test_force_login_project_detail_with_user(
     url = reverse("projects:project", kwargs={"id": project.id})
     response = client.get(url)
     assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
+def test_no_login_status_projects_commitment(client, project):
+    url = reverse(
+        "projects:status_projects_commitment", kwargs={"project_id": project.id}
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
+def test_no_login_status_projectobjective(client, project_objective):
+    url = reverse(
+        "projects:status_projectobjective",
+        kwargs={"projectobjective_id": project_objective.id},
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
+def test_no_login_status_dashboardprojectobjective(client, project_objective):
+    url = reverse(
+        "projects:status_dashboardprojectobjective",
+        kwargs={"projectobjective_id": project_objective.id},
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_status_projects_commitment(client, project):
+    url = reverse(
+        "projects:status_projects_commitment", kwargs={"project_id": project.id}
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 302
+    assert response.url == f"{reverse('login')}?next={url}"
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_status_projectobjective(client, project_objective):
+    url = reverse(
+        "projects:status_projectobjective",
+        kwargs={"projectobjective_id": project_objective.id},
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 302
+    assert response.url == f"{reverse('login')}?next={url}"
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_status_dashboardprojectobjective(client, project_objective):
+    url = reverse(
+        "projects:status_dashboardprojectobjective",
+        kwargs={"projectobjective_id": project_objective.id},
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 302
+    assert response.url == f"{reverse('login')}?next={url}"
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_status_projects_commitment_with_user(
+    client, user_without_permissions, project
+):
+    url = reverse(
+        "projects:status_projects_commitment", kwargs={"project_id": project.id}
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_status_projectobjective_with_user(
+    client, user_without_permissions, project_objective
+):
+    url = reverse(
+        "projects:status_projectobjective",
+        kwargs={"projectobjective_id": project_objective.id},
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=True)
+def test_force_login_status_dashboardprojectobjective_with_user(
+    client, user_without_permissions, project_objective
+):
+    url = reverse(
+        "projects:status_dashboardprojectobjective",
+        kwargs={"projectobjective_id": project_objective.id},
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 200
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
+def test_status_projects_commitment_returns_404_for_unknown_id(client):
+    url = reverse("projects:status_projects_commitment", kwargs={"project_id": 999999})
+
+    response = client.get(url)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
+def test_status_projectobjective_returns_404_for_unknown_id(client):
+    url = reverse(
+        "projects:status_projectobjective",
+        kwargs={"projectobjective_id": 999999},
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+@override_settings(FORCE_LOGIN=False)
+def test_status_dashboardprojectobjective_returns_404_for_unknown_id(client):
+    url = reverse(
+        "projects:status_dashboardprojectobjective",
+        kwargs={"projectobjective_id": 999999},
+    )
+
+    response = client.get(url)
+
+    assert response.status_code == 404

--- a/dashboard/projects/test_views.py
+++ b/dashboard/projects/test_views.py
@@ -489,9 +489,7 @@ def test_force_login_status_projectobjective_with_user(
         "projects:status_projectobjective",
         kwargs={"projectobjective_id": project_objective.id},
     )
-
     response = client.get(url)
-
     assert response.status_code == 200
 
 

--- a/dashboard/projects/views.py
+++ b/dashboard/projects/views.py
@@ -1,6 +1,6 @@
 import json
 from django.db.models import F, Sum
-from django.shortcuts import render, HttpResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404, render, HttpResponse, HttpResponseRedirect
 from django.views.generic import ListView
 from django.views.decorators.http import require_http_methods
 from django.forms import inlineformset_factory
@@ -137,10 +137,11 @@ def project(request, id):
 
 # detail view status methods
 
+@conditional_login_required
 @require_http_methods(["GET"])
 def status_projects_commitment(request, project_id):
 
-    project = Project.objects.get(id=project_id)
+    project = get_object_or_404(Project, id=project_id)
     current_commitments = Commitment.objects.filter(
         project=project, work_cycle__is_current=True, committed=True
     )
@@ -155,10 +156,11 @@ def status_projects_commitment(request, project_id):
         },
     )
 
-@require_http_methods("GET")
+@conditional_login_required
+@require_http_methods(["GET"])
 def status_projectobjective(request, projectobjective_id):
 
-    projectobjective = ProjectObjective.objects.get(id=projectobjective_id)
+    projectobjective = get_object_or_404(ProjectObjective, id=projectobjective_id)
 
     return render(
         request,
@@ -171,9 +173,10 @@ def status_projectobjective(request, projectobjective_id):
 
 # list view status methods
 
-@require_http_methods("GET")
+@conditional_login_required
+@require_http_methods(["GET"])
 def status_dashboardprojectobjective(request, projectobjective_id):
-    projectobjective = ProjectObjective.objects.get(id=projectobjective_id)
+    projectobjective = get_object_or_404(ProjectObjective, id=projectobjective_id)
 
     return render(
         request,

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -2,7 +2,7 @@ name: dashboard
 # see https://documentation.ubuntu.com/rockcraft/en/1.8.0/explanation/bases/
 # for more information about bases and using 'bare' bases for chiselled rocks
 base: ubuntu@22.04 # the base environment for this Django application
-version: "0.57" # just for humans. Semantic versioning is recommended
+version: "0.58" # just for humans. Semantic versioning is recommended
 summary: A summary of your Django application # 79 char long summary
 description: |
   Dashboard is a Django application to track quality and progress of multiple


### PR DESCRIPTION
This PR fixes some data leaks when `DJANGO_FORCE_LOGIN` is enabled.

Example leak:

```
/status_dashboardprojectobjective/2

<td class="deferred">
  <a href="/2/#chemistry-colourfulness ">
    Deferred
  </a>
</td>
```

This is bad because "chemistry" could be the name of a commercially-sensitive project.

---

### Manual checks

- [x] If you changed the Dashboard application or the rock, have you increased the version number in `rockcraft.yaml`? Remember to use the same version number in `README.md`.
