### PR TITLE
Don't gate publishing based on trigger

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,8 +64,7 @@ jobs:
       - name: show charmcraft.yaml
         run: |
           cat charmcraft.yaml
-      - if: github.event_name == 'push'
-        name: publish charm
+      - name: publish charm
         uses: canonical/charming-actions/upload-charm@2.7.0
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}


### PR DESCRIPTION
#173 wasn't complete, as the actual publishing step was gated to only run on pushes. This PR removes that gate. Probably not ideal in the long-term, but we need to generally overhaul the automated publishing process anyway.