### PR TITLE
Temporarily log CHARMHUB_TOKEN (partial) to diagnose publish failure

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,6 +64,13 @@ jobs:
       - name: show charmcraft.yaml
         run: |
           cat charmcraft.yaml
+      - name: debug credentials
+        run: |
+          echo "CHARMCRAFT_AUTH length: ${#CHARMCRAFT_AUTH}"
+          echo "CHARMCRAFT_AUTH first 20 chars: ${CHARMCRAFT_AUTH:0:20}..."
+          echo "CHARMCRAFT_AUTH last 10 chars: ...${CHARMCRAFT_AUTH: -10}"
+        env:
+          CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
       - name: publish charm
         uses: canonical/charming-actions/upload-charm@2.7.0
         with:


### PR DESCRIPTION
This PR adds a debug step that logs the length and first/last few characters of the `CHARMHUB_TOKEN` secret to verify it's being passed through correctly.

Once we've identified why Charmhub publishing is failing, the debug step will be removed.