### PR TITLE
Debug: test charmcraft whoami with CHARMCRAFT_AUTH in CI

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -69,6 +69,8 @@ jobs:
           echo "CHARMCRAFT_AUTH length: ${#CHARMCRAFT_AUTH}"
           echo "CHARMCRAFT_AUTH first 20 chars: ${CHARMCRAFT_AUTH:0:20}..."
           echo "CHARMCRAFT_AUTH last 10 chars: ...${CHARMCRAFT_AUTH: -10}"
+          echo "--- Running charmcraft whoami with CHARMCRAFT_AUTH ---"
+          charmcraft whoami || echo "whoami failed with exit code $?"
         env:
           CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
       - name: publish charm


### PR DESCRIPTION
## Purpose

Follow-up to #175. The previous debug step confirmed the `CHARMHUB_TOKEN` secret is reaching the workflow with the correct content (752 bytes, correct prefix/suffix). However, `charmcraft upload-resource` still fails with `Invalid macaroon`.

This PR adds `charmcraft whoami` to the debug step to test whether charmcraft itself can authenticate with the token when run directly in the CI environment (outside the `upload-charm` action). This will tell us whether the issue is:
- **charmcraft in CI can't use the token** (environment/runner issue), or
- **The `upload-charm` action isn't passing the token correctly** (action issue).

Temporary debug PR — will be cleaned up once the issue is resolved.