### PR TITLE
Revert debugging in publish workflow; add write permission; upgrade actions

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -64,15 +64,6 @@ jobs:
       - name: show charmcraft.yaml
         run: |
           cat charmcraft.yaml
-      - name: debug credentials
-        run: |
-          echo "CHARMCRAFT_AUTH length: ${#CHARMCRAFT_AUTH}"
-          echo "CHARMCRAFT_AUTH first 20 chars: ${CHARMCRAFT_AUTH:0:20}..."
-          echo "CHARMCRAFT_AUTH last 10 chars: ...${CHARMCRAFT_AUTH: -10}"
-          echo "--- Running charmcraft whoami with CHARMCRAFT_AUTH ---"
-          charmcraft whoami || echo "whoami failed with exit code $?"
-        env:
-          CHARMCRAFT_AUTH: ${{ secrets.CHARMHUB_TOKEN }}
       - name: publish charm
         uses: canonical/charming-actions/upload-charm@2.7.0
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,9 +18,11 @@ jobs:
         arch: [amd64, arm64]
     runs-on: [self-hosted, linux, "${{ matrix.arch }}"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+        with:
+          persist-credentials: false
       - name: setup lxd
-        uses: canonical/setup-lxd@v0.1.2
+        uses: canonical/setup-lxd@8c6a87bfb56aa48f3fb9b830baa18562d8bfd4ee  # v1
       - name: build rock
         run: |
           set -x
@@ -29,7 +31,7 @@ jobs:
           docker run -d -p 5000:5000 --name registry registry:latest
           rockcraft.skopeo --insecure-policy copy --dest-tls-verify=false oci-archive:$(ls *.rock) docker://localhost:5000/dashboard:latest
       - name: upload rock
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: rock-${{ matrix.arch }}
           path: "*.rock"
@@ -44,7 +46,7 @@ jobs:
           charmcraft pack --verbosity trace
           echo charms=`ls *.charm` >> $GITHUB_OUTPUT
       - name: upload charm
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: charm-${{ matrix.arch }}
           path: ./charm/${{ steps.charmcraft.outputs.charms }}
@@ -67,7 +69,7 @@ jobs:
         run: |
           cat charmcraft.yaml
       - name: publish charm
-        uses: canonical/charming-actions/upload-charm@2.7.0
+        uses: canonical/charming-actions/upload-charm@1753e0803f70445132e92acd45c905aba6473225  # 2.7.0
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   publish-charm:
     name: Publish charm and rock
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       max-parallel: 1


### PR DESCRIPTION
This PR reverts the token debugging I added in #175 and #176. The issue was https://github.com/canonical/charmcraft/issues/2806: my token was generated with Charmcraft 4.3, but Charmcraft 4.4 (used in the workflow) changed the expected format. I regenerated a token with Charmcraft 4.4.

This PR also sets `write` permission, which is needed after a GitHub change.

I'm also upgrading and pinning the actions used in the workflow.